### PR TITLE
feat: build multi-model ensemble with BT and ANN

### DIFF
--- a/trainer/featureBuild_bt.js
+++ b/trainer/featureBuild_bt.js
@@ -1,0 +1,295 @@
+// trainer/featureBuild_bt.js
+//
+// Build Bradley-Terry feature set using nflverse team-week stats.
+// Output one row per game (home-team perspective) with differential features.
+
+const BT_FEATURES = [
+  "diff_total_yards",
+  "diff_penalty_yards",
+  "diff_turnovers",
+  "diff_possession_seconds",
+  "diff_r_ratio",
+  "delta_power_rank"
+];
+
+const num = (v, d = 0) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+};
+
+const parsePossession = (value) => {
+  if (!value) return 0;
+  if (typeof value === "number") return value;
+  const s = String(value).trim();
+  if (!s) return 0;
+  if (/^\d+$/.test(s)) return Number(s);
+  const parts = s.split(":").map((p) => Number(p));
+  if (parts.length === 2 && parts.every((v) => Number.isFinite(v))) {
+    return parts[0] * 60 + parts[1];
+  }
+  if (parts.length === 3 && parts.every((v) => Number.isFinite(v))) {
+    return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  }
+  return 0;
+};
+
+const finalScores = (g) => {
+  const hs = g.home_score ?? g.home_points ?? g.home_pts;
+  const as = g.away_score ?? g.away_points ?? g.away_pts;
+  if (!Number.isFinite(Number(hs)) || !Number.isFinite(Number(as))) return null;
+  return { hs: Number(hs), as: Number(as) };
+};
+
+const winLabel = (g) => {
+  const fs = finalScores(g);
+  if (!fs) return null;
+  if (fs.hs === fs.as) return null;
+  return fs.hs > fs.as ? 1 : 0;
+};
+
+const isReg = (v) => {
+  if (v == null) return true;
+  const s = String(v).trim().toUpperCase();
+  return s === "" || s.startsWith("REG");
+};
+
+function baseStats(row = {}) {
+  const pass = num(row.passing_yards ?? row.pass_yards ?? row.pass_yds);
+  const rush = num(row.rushing_yards ?? row.rush_yards ?? row.rush_yds);
+  const totalRaw = row.total_yards ?? row.total_yards_gained ?? row.total_yds;
+  const total = num(totalRaw, pass + rush);
+  const penalties = num(row.penalty_yards ?? row.penalties_yards ?? row.penalty_yards_y);
+  const turnovers = num(
+    row.turnovers ??
+      row.turnover ??
+      row.turnovers_total ??
+      (row.interceptions ?? row.passing_interceptions ?? 0) +
+        (row.fumbles_lost ?? row.rushing_fumbles_lost ?? 0) +
+        (row.receiving_fumbles_lost ?? 0) +
+        (row.sack_fumbles_lost ?? 0)
+  );
+  const poss = parsePossession(
+    row.possession_time ?? row.time_of_possession ?? row.time_possession ?? row.possession_seconds
+  );
+  const sacks = num(row.sacks ?? row.sack_total ?? row.qb_sacked ?? row.sacks_taken);
+  const plays = num(row.offensive_plays ?? row.offensive_plays_run ?? 0);
+  return {
+    total_yards: total,
+    pass_yards: pass,
+    rush_yards: rush,
+    penalty_yards: penalties,
+    turnovers,
+    possession_seconds: poss,
+    sacks,
+    offensive_plays: plays
+  };
+}
+
+function blend(currentAvg, prevAvg, week) {
+  const prevWeight = Math.max(0, 0.8 - 0.2 * (week - 1));
+  const currWeight = 1 - prevWeight;
+  const blendField = (k) => prevWeight * num(prevAvg?.[k]) + currWeight * num(currentAvg?.[k]);
+  const total = blendField("total_yards");
+  const pass = blendField("pass_yards");
+  const ratio = total ? pass / total : 0;
+  return {
+    total_yards: total,
+    penalty_yards: blendField("penalty_yards"),
+    turnovers: blendField("turnovers"),
+    possession_seconds: blendField("possession_seconds"),
+    r_ratio: ratio,
+    sacks: blendField("sacks"),
+    offensive_plays: blendField("offensive_plays")
+  };
+}
+
+function avgFromTotals(totals) {
+  const games = Math.max(1, totals.games || 0);
+  return {
+    total_yards: num(totals.total_yards) / games,
+    penalty_yards: num(totals.penalty_yards) / games,
+    turnovers: num(totals.turnovers) / games,
+    possession_seconds: num(totals.possession_seconds) / games,
+    pass_yards: num(totals.pass_yards) / games,
+    sacks: num(totals.sacks) / games,
+    offensive_plays: num(totals.offensive_plays) / games
+  };
+}
+
+function enrichWithRatio(avg) {
+  const total = num(avg.total_yards);
+  const pass = num(avg.pass_yards);
+  return { ...avg, r_ratio: total ? pass / total : 0 };
+}
+
+function seedPrevAverages(prevTeamWeekly) {
+  const byTeam = new Map();
+  for (const row of prevTeamWeekly || []) {
+    const team = row.team || row.team_abbr || row.team_code;
+    if (!team) continue;
+    const stats = baseStats(row);
+    const prev = byTeam.get(team) || { games: 0, total_yards: 0, penalty_yards: 0, turnovers: 0, possession_seconds: 0, pass_yards: 0, sacks: 0, offensive_plays: 0 };
+    prev.games += 1;
+    prev.total_yards += stats.total_yards;
+    prev.penalty_yards += stats.penalty_yards;
+    prev.turnovers += stats.turnovers;
+    prev.possession_seconds += stats.possession_seconds;
+    prev.pass_yards += stats.pass_yards;
+    prev.sacks += stats.sacks;
+    prev.offensive_plays += stats.offensive_plays;
+    byTeam.set(team, prev);
+  }
+  const out = new Map();
+  for (const [team, totals] of byTeam.entries()) {
+    out.set(team, enrichWithRatio(avgFromTotals(totals)));
+  }
+  return out;
+}
+
+function mkGameId(season, week, home, away) {
+  return `${season}-W${String(week).padStart(2, "0")}-${home}-${away}`;
+}
+
+export function buildBTFeatures({ schedules, teamWeekly, season, prevTeamWeekly }) {
+  const regSched = (schedules || []).filter(
+    (g) => Number(g.season) === Number(season) && isReg(g.season_type)
+  );
+  const weeks = [...new Set(regSched.map((g) => Number(g.week)).filter(Number.isFinite))].sort(
+    (a, b) => a - b
+  );
+
+  const twSeason = (teamWeekly || []).filter((r) => Number(r.season) === Number(season));
+  const twIdx = new Map();
+  for (const row of twSeason) {
+    const team = row.team || row.team_abbr || row.team_code;
+    if (!team) continue;
+    const week = Number(row.week);
+    const key = `${season}-${week}-${team}`;
+    twIdx.set(key, row);
+  }
+
+  const prevMap = seedPrevAverages(prevTeamWeekly);
+  const rolling = new Map();
+  const out = [];
+
+  for (const team of new Set(regSched.flatMap((g) => [g.home_team, g.away_team]).filter(Boolean))) {
+    rolling.set(team, {
+      games: 0,
+      total_yards: 0,
+      penalty_yards: 0,
+      turnovers: 0,
+      possession_seconds: 0,
+      pass_yards: 0,
+      sacks: 0,
+      offensive_plays: 0
+    });
+  }
+
+  for (const W of weeks) {
+    const games = regSched.filter((g) => Number(g.week) === W);
+    if (!games.length) continue;
+
+    for (const g of games) {
+      const home = g.home_team;
+      const away = g.away_team;
+      if (!home || !away) continue;
+      const hKeyPrev = `${season}-${W}-${home}`;
+      const aKeyPrev = `${season}-${W}-${away}`;
+      const hRow = twIdx.get(hKeyPrev) || {};
+      const aRow = twIdx.get(aKeyPrev) || {};
+      const hActual = baseStats(hRow);
+      const aActual = baseStats(aRow);
+
+      const hTotals = rolling.get(home) || { games: 0 };
+      const aTotals = rolling.get(away) || { games: 0 };
+      const hAvg = enrichWithRatio(avgFromTotals(hTotals));
+      const aAvg = enrichWithRatio(avgFromTotals(aTotals));
+
+      const hPrev = prevMap.get(home) || enrichWithRatio({
+        total_yards: 0,
+        penalty_yards: 0,
+        turnovers: 0,
+        possession_seconds: 0,
+        pass_yards: 0,
+        sacks: 0,
+        offensive_plays: 0
+      });
+      const aPrev = prevMap.get(away) || enrichWithRatio({
+        total_yards: 0,
+        penalty_yards: 0,
+        turnovers: 0,
+        possession_seconds: 0,
+        pass_yards: 0,
+        sacks: 0,
+        offensive_plays: 0
+      });
+
+      const hBlend = blend({ ...hAvg, r_ratio: hAvg.r_ratio }, hPrev, W);
+      const aBlend = blend({ ...aAvg, r_ratio: aAvg.r_ratio }, aPrev, W);
+
+      const hPower = num(
+        g.elo1_pre ?? g.elo1_post ?? g.elo1 ?? g.elo ?? g.elo_prob1 ?? g.elo_home ?? 1500,
+        1500
+      );
+      const aPower = num(
+        g.elo2_pre ?? g.elo2_post ?? g.elo2 ?? g.elo ?? g.elo_prob2 ?? g.elo_away ?? 1500,
+        1500
+      );
+
+      const features = {
+        diff_total_yards: num(hBlend.total_yards) - num(aBlend.total_yards),
+        diff_penalty_yards: num(hBlend.penalty_yards) - num(aBlend.penalty_yards),
+        diff_turnovers: num(hBlend.turnovers) - num(aBlend.turnovers),
+        diff_possession_seconds: num(hBlend.possession_seconds) - num(aBlend.possession_seconds),
+        diff_r_ratio: num(hBlend.r_ratio) - num(aBlend.r_ratio),
+        delta_power_rank: hPower - aPower
+      };
+
+      const label = winLabel(g);
+      const game_id = mkGameId(season, W, home, away);
+
+      out.push({
+        season: Number(season),
+        week: Number(W),
+        game_id,
+        home_team: home,
+        away_team: away,
+        features,
+        label_win: label,
+        home_context: { ...hBlend, power_rank: hPower },
+        away_context: { ...aBlend, power_rank: aPower },
+        home_actual: { ...hActual, r_ratio: hActual.total_yards ? hActual.pass_yards / hActual.total_yards : 0 },
+        away_actual: { ...aActual, r_ratio: aActual.total_yards ? aActual.pass_yards / aActual.total_yards : 0 }
+      });
+
+      // update rolling + history with actual stats after emitting row (so next week sees them)
+      const hRoll = rolling.get(home);
+      if (hRoll) {
+        hRoll.games += 1;
+        hRoll.total_yards += hActual.total_yards;
+        hRoll.penalty_yards += hActual.penalty_yards;
+        hRoll.turnovers += hActual.turnovers;
+        hRoll.possession_seconds += hActual.possession_seconds;
+        hRoll.pass_yards += hActual.pass_yards;
+        hRoll.sacks += hActual.sacks;
+        hRoll.offensive_plays += hActual.offensive_plays;
+      }
+      const aRoll = rolling.get(away);
+      if (aRoll) {
+        aRoll.games += 1;
+        aRoll.total_yards += aActual.total_yards;
+        aRoll.penalty_yards += aActual.penalty_yards;
+        aRoll.turnovers += aActual.turnovers;
+        aRoll.possession_seconds += aActual.possession_seconds;
+        aRoll.pass_yards += aActual.pass_yards;
+        aRoll.sacks += aActual.sacks;
+        aRoll.offensive_plays += aActual.offensive_plays;
+      }
+
+    }
+  }
+
+  return out;
+}
+
+export { BT_FEATURES };

--- a/trainer/model_ann.js
+++ b/trainer/model_ann.js
@@ -1,0 +1,307 @@
+// trainer/model_ann.js
+// Lightweight ANN committee for win probability estimation
+
+const sigmoid = (z) => 1 / (1 + Math.exp(-z));
+const tanh = (z) => Math.tanh(z);
+const dtanh = (z) => 1 - Math.tanh(z) ** 2;
+
+function makeLCG(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+function initMatrix(rows, cols, rng, scale = 0.1) {
+  const m = new Array(rows);
+  for (let r = 0; r < rows; r++) {
+    const row = new Array(cols);
+    for (let c = 0; c < cols; c++) {
+      row[c] = (rng() * 2 - 1) * scale;
+    }
+    m[r] = row;
+  }
+  return m;
+}
+
+function initVector(size, val = 0) {
+  return new Array(size).fill(val);
+}
+
+function dotVec(a, b) {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += a[i] * b[i];
+  return s;
+}
+
+function matVec(W, v) {
+  return W.map((row) => dotVec(row, v));
+}
+
+function addVec(a, b) {
+  return a.map((v, i) => v + (b[i] ?? 0));
+}
+
+function applyFunc(v, fn) {
+  return v.map(fn);
+}
+
+function zeroLike(mat) {
+  return mat.map((row) => row.map(() => 0));
+}
+
+function forward(network, x) {
+  const { W1, b1, W2, b2, W3, b3 } = network;
+  const z1 = addVec(matVec(W1, x), b1);
+  const a1 = applyFunc(z1, tanh);
+  const z2 = addVec(matVec(W2, a1), b2);
+  const a2 = applyFunc(z2, tanh);
+  const z3 = dotVec(W3[0], a2) + b3[0];
+  const out = sigmoid(z3);
+  return { z1, a1, z2, a2, z3, out };
+}
+
+function backward(network, cache, x, target) {
+  const { W2, W3 } = network;
+  const { z1, a1, z2, a2, out } = cache;
+  const delta3 = out - target;
+  const gradW3 = [a2.map((v) => delta3 * v)];
+  const gradb3 = [delta3];
+  const delta2 = new Array(a2.length).fill(0);
+  for (let j = 0; j < a2.length; j++) {
+    delta2[j] = delta3 * W3[0][j] * dtanh(z2[j]);
+  }
+  const gradW2 = zeroLike(W2);
+  const gradb2 = new Array(a2.length).fill(0);
+  for (let j = 0; j < a2.length; j++) {
+    for (let k = 0; k < a1.length; k++) {
+      gradW2[j][k] += delta2[j] * a1[k];
+    }
+    gradb2[j] += delta2[j];
+  }
+  const delta1 = new Array(a1.length).fill(0);
+  for (let j = 0; j < a1.length; j++) {
+    let sum = 0;
+    for (let k = 0; k < a2.length; k++) sum += delta2[k] * network.W2[k][j];
+    delta1[j] = sum * dtanh(z1[j]);
+  }
+  const gradW1 = zeroLike(network.W1);
+  const gradb1 = new Array(a1.length).fill(0);
+  for (let j = 0; j < a1.length; j++) {
+    for (let k = 0; k < x.length; k++) gradW1[j][k] += delta1[j] * x[k];
+    gradb1[j] += delta1[j];
+  }
+  return { gradW3, gradb3, gradW2, gradb2, gradW1, gradb1 };
+}
+
+function updateNetwork(network, grads, lr) {
+  const { gradW3, gradb3, gradW2, gradb2, gradW1, gradb1 } = grads;
+  for (let j = 0; j < network.W3.length; j++) {
+    for (let k = 0; k < network.W3[j].length; k++) {
+      network.W3[j][k] -= lr * gradW3[j][k];
+    }
+  }
+  network.b3[0] -= lr * gradb3[0];
+  for (let j = 0; j < network.W2.length; j++) {
+    for (let k = 0; k < network.W2[j].length; k++) {
+      network.W2[j][k] -= lr * gradW2[j][k];
+    }
+    network.b2[j] -= lr * gradb2[j];
+  }
+  for (let j = 0; j < network.W1.length; j++) {
+    for (let k = 0; k < network.W1[j].length; k++) {
+      network.W1[j][k] -= lr * gradW1[j][k];
+    }
+    network.b1[j] -= lr * gradb1[j];
+  }
+}
+
+function copyNetwork(network) {
+  return {
+    W1: network.W1.map((row) => row.slice()),
+    b1: network.b1.slice(),
+    W2: network.W2.map((row) => row.slice()),
+    b2: network.b2.slice(),
+    W3: network.W3.map((row) => row.slice()),
+    b3: network.b3.slice()
+  };
+}
+
+function lossBCE(pred, target) {
+  const eps = 1e-12;
+  return -(target * Math.log(Math.max(pred, eps)) + (1 - target) * Math.log(Math.max(1 - pred, eps)));
+}
+
+function splitTrainVal(X, y, valFraction = 0.2) {
+  const n = X.length;
+  const valSize = Math.min(Math.max(1, Math.floor(n * valFraction)), Math.max(1, n - 1));
+  const trainSize = Math.max(1, n - valSize);
+  const idx = Array.from({ length: n }, (_, i) => i);
+  return {
+    trainIdx: idx.slice(0, trainSize),
+    valIdx: idx.slice(trainSize)
+  };
+}
+
+function selectRows(X, idx) {
+  return idx.map((i) => X[i]);
+}
+
+function selectVals(arr, idx) {
+  return idx.map((i) => arr[i]);
+}
+
+function trainSingleNetwork(X, y, { seed = 1, maxEpochs = 200, lr = 1e-3, patience = 10 }) {
+  const rng = makeLCG(seed);
+  const inputDim = X[0]?.length || 0;
+  const hidden1 = 32;
+  const hidden2 = 16;
+  const net = {
+    W1: initMatrix(hidden1, inputDim, rng, 0.25 / Math.sqrt(Math.max(1, inputDim))),
+    b1: initVector(hidden1),
+    W2: initMatrix(hidden2, hidden1, rng, 0.25 / Math.sqrt(Math.max(1, hidden1))),
+    b2: initVector(hidden2),
+    W3: initMatrix(1, hidden2, rng, 0.25 / Math.sqrt(Math.max(1, hidden2))),
+    b3: initVector(1)
+  };
+
+  if (X.length <= 1) {
+    return { network: net, epochs: 0, bestLoss: Infinity };
+  }
+
+  const { trainIdx, valIdx } = splitTrainVal(X, y, Math.min(0.2, Math.max(0.1, 1 / Math.max(2, X.length))));
+  const Xtrain = selectRows(X, trainIdx);
+  const ytrain = selectVals(y, trainIdx);
+  const Xval = selectRows(X, valIdx.length ? valIdx : trainIdx);
+  const yval = selectVals(y, valIdx.length ? valIdx : trainIdx);
+
+  let best = copyNetwork(net);
+  let bestLoss = Infinity;
+  let badRounds = 0;
+
+  for (let epoch = 0; epoch < maxEpochs; epoch++) {
+    const grads = {
+      gradW3: zeroLike(net.W3),
+      gradb3: [0],
+      gradW2: zeroLike(net.W2),
+      gradb2: new Array(net.W2.length).fill(0),
+      gradW1: zeroLike(net.W1),
+      gradb1: new Array(net.W1.length).fill(0)
+    };
+    for (let i = 0; i < Xtrain.length; i++) {
+      const cache = forward(net, Xtrain[i]);
+      const g = backward(net, cache, Xtrain[i], ytrain[i]);
+      for (let j = 0; j < net.W3.length; j++) {
+        for (let k = 0; k < net.W3[j].length; k++) grads.gradW3[j][k] += g.gradW3[j][k];
+      }
+      grads.gradb3[0] += g.gradb3[0];
+      for (let j = 0; j < net.W2.length; j++) {
+        for (let k = 0; k < net.W2[j].length; k++) grads.gradW2[j][k] += g.gradW2[j][k];
+        grads.gradb2[j] += g.gradb2[j];
+      }
+      for (let j = 0; j < net.W1.length; j++) {
+        for (let k = 0; k < net.W1[j].length; k++) grads.gradW1[j][k] += g.gradW1[j][k];
+        grads.gradb1[j] += g.gradb1[j];
+      }
+    }
+    const denom = Math.max(1, Xtrain.length);
+    for (let j = 0; j < net.W3.length; j++) {
+      for (let k = 0; k < net.W3[j].length; k++) grads.gradW3[j][k] /= denom;
+    }
+    grads.gradb3[0] /= denom;
+    for (let j = 0; j < net.W2.length; j++) {
+      for (let k = 0; k < net.W2[j].length; k++) grads.gradW2[j][k] /= denom;
+      grads.gradb2[j] /= denom;
+    }
+    for (let j = 0; j < net.W1.length; j++) {
+      for (let k = 0; k < net.W1[j].length; k++) grads.gradW1[j][k] /= denom;
+      grads.gradb1[j] /= denom;
+    }
+    updateNetwork(net, grads, lr);
+
+    // validation
+    let valLoss = 0;
+    for (let i = 0; i < Xval.length; i++) {
+      const pred = forward(net, Xval[i]).out;
+      valLoss += lossBCE(pred, yval[i]);
+    }
+    valLoss /= Math.max(1, Xval.length);
+    if (valLoss + 1e-6 < bestLoss) {
+      bestLoss = valLoss;
+      best = copyNetwork(net);
+      badRounds = 0;
+    } else {
+      badRounds += 1;
+      if (badRounds >= patience) break;
+    }
+  }
+
+  return { network: best, epochs: 0, bestLoss };
+}
+
+export function trainANNCommittee(X, y, {
+  seeds = 15,
+  maxEpochs = Number(process.env.ANN_MAX_EPOCHS ?? 200),
+  lr = 1e-3,
+  patience = 10,
+  timeLimitMs = 60000
+} = {}) {
+  if (!X?.length) {
+    return { models: [], seeds: [], architecture: [0, 32, 16, 1] };
+  }
+  const start = Date.now();
+  const models = [];
+  const usedSeeds = [];
+  const maxSeeds = Math.max(1, Math.round(seeds));
+  for (let i = 0; i < maxSeeds; i++) {
+    const seed = i + 1;
+    const result = trainSingleNetwork(X, y, { seed, maxEpochs, lr, patience });
+    models.push(result.network);
+    usedSeeds.push(seed);
+    if (Date.now() - start > timeLimitMs) break;
+  }
+  return {
+    models,
+    seeds: usedSeeds,
+    architecture: [X[0]?.length || 0, 32, 16, 1]
+  };
+}
+
+export function predictANNCommittee(model, X) {
+  if (!model?.models?.length) return X.map(() => 0.5);
+  const probs = new Array(X.length).fill(0);
+  for (const net of model.models) {
+    for (let i = 0; i < X.length; i++) {
+      probs[i] += forward(net, X[i]).out;
+    }
+  }
+  return probs.map((p) => p / model.models.length);
+}
+
+function gradientSingle(net, x) {
+  const { z1, a1, z2, a2, out } = forward(net, x);
+  const delta3 = out * (1 - out);
+  const grad = new Array(x.length).fill(0);
+  for (let j = 0; j < a2.length; j++) {
+    const delta2 = delta3 * net.W3[0][j] * dtanh(z2[j]);
+    for (let k = 0; k < a1.length; k++) {
+      const delta1 = delta2 * net.W2[j][k] * dtanh(z1[k]);
+      for (let m = 0; m < x.length; m++) {
+        grad[m] += delta1 * net.W1[k][m];
+      }
+    }
+  }
+  return grad;
+}
+
+export function gradientANNCommittee(model, x) {
+  if (!model?.models?.length) return new Array(x.length).fill(0);
+  const grad = new Array(x.length).fill(0);
+  for (const net of model.models) {
+    const g = gradientSingle(net, x);
+    for (let i = 0; i < grad.length; i++) grad[i] += g[i];
+  }
+  for (let i = 0; i < grad.length; i++) grad[i] /= model.models.length;
+  return grad;
+}

--- a/trainer/model_bt.js
+++ b/trainer/model_bt.js
@@ -1,0 +1,220 @@
+// trainer/model_bt.js
+// Bradley-Terry style logistic model with bootstrap simulation
+
+import { BT_FEATURES } from "./featureBuild_bt.js";
+
+const sigmoid = (z) => 1 / (1 + Math.exp(-z));
+
+const fitScaler = (X) => {
+  const d = X[0]?.length || 0;
+  const mu = new Array(d).fill(0);
+  const sd = new Array(d).fill(1);
+  const n = Math.max(1, X.length);
+  for (let j = 0; j < d; j++) {
+    let s = 0;
+    for (let i = 0; i < X.length; i++) s += X[i][j];
+    mu[j] = s / n;
+  }
+  for (let j = 0; j < d; j++) {
+    let s = 0;
+    for (let i = 0; i < X.length; i++) {
+      const v = X[i][j] - mu[j];
+      s += v * v;
+    }
+    sd[j] = Math.sqrt(s / n) || 1;
+  }
+  return { mu, sd };
+};
+
+const applyScaler = (X, scaler) => {
+  if (!scaler) return X.map((row) => row.slice());
+  const { mu, sd } = scaler;
+  return X.map((row) => row.map((v, j) => (v - mu[j]) / (sd[j] || 1)));
+};
+
+function trainLogisticGD(X, y, { steps = 2000, lr = 5e-3, l2 = 1e-4 } = {}) {
+  const n = X.length;
+  const d = X[0]?.length || 0;
+  let w = new Array(d).fill(0);
+  let b = 0;
+  for (let t = 0; t < steps; t++) {
+    let gb = 0;
+    const gw = new Array(d).fill(0);
+    for (let i = 0; i < n; i++) {
+      const xi = X[i];
+      const z = xi.reduce((s, v, idx) => s + v * w[idx], 0) + b;
+      const p = sigmoid(z);
+      const err = p - y[i];
+      gb += err;
+      for (let j = 0; j < d; j++) gw[j] += err * xi[j];
+    }
+    gb /= Math.max(1, n);
+    for (let j = 0; j < d; j++) gw[j] = gw[j] / Math.max(1, n) + l2 * w[j];
+    b -= lr * gb;
+    for (let j = 0; j < d; j++) w[j] -= lr * gw[j];
+  }
+  return { w, b };
+}
+
+const predictLogit = (X, model) => {
+  const { w, b } = model;
+  return X.map((row) => sigmoid(row.reduce((s, v, idx) => s + v * w[idx], 0) + b));
+};
+
+const rowsToMatrix = (rows) => rows.map((r) => BT_FEATURES.map((k) => Number(r.features?.[k] ?? 0)));
+
+export function trainBTModel(trainRows, { steps, lr, l2 } = {}) {
+  const X = rowsToMatrix(trainRows);
+  const y = trainRows.map((r) => Number(r.label_win ?? 0));
+  const scaler = fitScaler(X);
+  const Xs = applyScaler(X, scaler);
+  const model = trainLogisticGD(Xs, y, { steps, lr, l2 });
+  return { ...model, scaler, features: BT_FEATURES.slice() };
+}
+
+function percentile(sorted, pct) {
+  if (!sorted.length) return 0.5;
+  const idx = (sorted.length - 1) * pct;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function sampleRecent(history, k, rng) {
+  if (!history?.length) return null;
+  const pool = history.slice(-Math.min(k, history.length));
+  if (!pool.length) return null;
+  const sample = [];
+  for (let i = 0; i < k; i++) {
+    const idx = Math.floor(rng() * pool.length);
+    sample.push(pool[idx]);
+  }
+  return sample;
+}
+
+function averageStats(samples) {
+  if (!samples || !samples.length) return null;
+  const agg = {
+    total_yards: 0,
+    penalty_yards: 0,
+    turnovers: 0,
+    possession_seconds: 0,
+    r_ratio: 0
+  };
+  for (const s of samples) {
+    agg.total_yards += Number(s.total_yards ?? 0);
+    agg.penalty_yards += Number(s.penalty_yards ?? 0);
+    agg.turnovers += Number(s.turnovers ?? 0);
+    agg.possession_seconds += Number(s.possession_seconds ?? 0);
+    agg.r_ratio += Number(s.r_ratio ?? 0);
+  }
+  const n = samples.length;
+  return {
+    total_yards: agg.total_yards / n,
+    penalty_yards: agg.penalty_yards / n,
+    turnovers: agg.turnovers / n,
+    possession_seconds: agg.possession_seconds / n,
+    r_ratio: agg.r_ratio / n
+  };
+}
+
+function defaultRng(seed = 1234567) {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+function buildHistory(rows) {
+  const history = new Map();
+  for (const row of rows) {
+    const push = (team, actual) => {
+      if (!team || !actual) return;
+      const arr = history.get(team) || [];
+      arr.push({
+        total_yards: Number(actual.total_yards ?? 0),
+        penalty_yards: Number(actual.penalty_yards ?? 0),
+        turnovers: Number(actual.turnovers ?? 0),
+        possession_seconds: Number(actual.possession_seconds ?? 0),
+        r_ratio: Number(actual.r_ratio ?? 0)
+      });
+      history.set(team, arr);
+    };
+    push(row.home_team, row.home_actual);
+    push(row.away_team, row.away_actual);
+  }
+  return history;
+}
+
+export function predictBT({
+  model,
+  rows,
+  historyRows,
+  bootstrap = Number(process.env.BT_B ?? 1000),
+  block = 5,
+  seed = 7
+}) {
+  const history = buildHistory(historyRows || []);
+  const scaler = model.scaler;
+  const coeffs = model.w;
+  const rng = defaultRng(seed);
+  const preds = [];
+  for (const row of rows) {
+    const base = BT_FEATURES.map((k) => Number(row.features?.[k] ?? 0));
+    const standardizedBase = applyScaler([base], scaler)[0];
+    const baseProb = sigmoid(
+      standardizedBase.reduce((s, v, idx) => s + v * coeffs[idx], 0) + model.b
+    );
+    const hHist = history.get(row.home_team) || [];
+    const aHist = history.get(row.away_team) || [];
+    const probs = [];
+    const iterations = Math.max(1, Math.round(bootstrap));
+    for (let i = 0; i < iterations; i++) {
+      const hSample = sampleRecent(hHist, block, rng);
+      const aSample = sampleRecent(aHist, block, rng);
+      if (!hSample || !aSample) {
+        probs.push(baseProb);
+        continue;
+      }
+      const hAvg = averageStats(hSample);
+      const aAvg = averageStats(aSample);
+      if (!hAvg || !aAvg) {
+        probs.push(baseProb);
+        continue;
+      }
+      const featVec = [
+        Number(hAvg.total_yards ?? 0) - Number(aAvg.total_yards ?? 0),
+        Number(hAvg.penalty_yards ?? 0) - Number(aAvg.penalty_yards ?? 0),
+        Number(hAvg.turnovers ?? 0) - Number(aAvg.turnovers ?? 0),
+        Number(hAvg.possession_seconds ?? 0) - Number(aAvg.possession_seconds ?? 0),
+        Number(hAvg.r_ratio ?? 0) - Number(aAvg.r_ratio ?? 0),
+        Number(row.features?.delta_power_rank ?? 0)
+      ];
+      const std = applyScaler([featVec], scaler)[0];
+      const prob = sigmoid(std.reduce((s, v, idx) => s + v * coeffs[idx], 0) + model.b);
+      probs.push(prob);
+    }
+    probs.sort((a, b) => a - b);
+    const mean = probs.reduce((s, v) => s + v, 0) / Math.max(1, probs.length);
+    const lo = percentile(probs, 0.05);
+    const hi = percentile(probs, 0.95);
+    preds.push({
+      game_id: row.game_id,
+      prob: mean,
+      ci90: [lo, hi],
+      base_prob: baseProb,
+      bootstrap_samples: probs.length,
+      features: BT_FEATURES.reduce((acc, k, idx) => ({ ...acc, [k]: base[idx] }), {})
+    });
+  }
+  return preds;
+}
+
+export function predictBTDeterministic(model, rows) {
+  const X = rowsToMatrix(rows);
+  const Xs = applyScaler(X, model.scaler);
+  const probs = predictLogit(Xs, model);
+  return rows.map((row, i) => ({ game_id: row.game_id, prob: probs[i] }));
+}

--- a/trainer/tests/backtest.js
+++ b/trainer/tests/backtest.js
@@ -1,0 +1,127 @@
+// trainer/tests/backtest.js
+// Backtest ensemble performance across recent weeks.
+
+import { runTraining } from "../train_multi.js";
+import { loadSchedules, loadTeamWeekly } from "../dataSources.js";
+
+const logloss = (probs, labels) => {
+  if (!labels.length) return null;
+  const eps = 1e-12;
+  let sum = 0;
+  for (let i = 0; i < labels.length; i++) {
+    const p = Math.min(Math.max(probs[i], eps), 1 - eps);
+    sum += -(labels[i] * Math.log(p) + (1 - labels[i]) * Math.log(1 - p));
+  }
+  return sum / labels.length;
+};
+
+function regression(points) {
+  if (!points.length) return { slope: 1, intercept: 0 };
+  const n = points.length;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (const { x, y } of points) {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const slope = (n * sumXY - sumX * sumY) / Math.max(1e-9, n * sumXX - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+  return { slope, intercept };
+}
+
+async function main() {
+  const season = Number(process.env.SEASON ?? new Date().getFullYear());
+  const schedules = await loadSchedules();
+  const teamWeekly = await loadTeamWeekly(season);
+  let prev = [];
+  try {
+    prev = await loadTeamWeekly(season - 1);
+  } catch (e) {
+    prev = [];
+  }
+
+  const weeks = [...new Set(teamWeekly.filter((r) => Number(r.season) === season).map((r) => Number(r.week)).filter(Number.isFinite))].sort((a, b) => a - b);
+  const maxWeek = weeks.length ? weeks[weeks.length - 1] : 0;
+  const targetWeeks = weeks.filter((w) => w >= 2 && w <= Math.min(maxWeek, Number(process.env.BACKTEST_WEEKS ?? 8)));
+
+  const results = [];
+  const calibrationPoints = [];
+
+  for (const week of targetWeeks) {
+    const run = await runTraining({
+      season,
+      week,
+      data: { schedules, teamWeekly, prevTeamWeekly: prev },
+      options: {
+        btBootstrapSamples: Number(process.env.BT_B ?? 300),
+        annSeeds: Number(process.env.ANN_SEEDS ?? 7),
+        annMaxEpochs: 150,
+        annCvMaxEpochs: 90,
+        annCvSeeds: 4,
+        weightStep: 0.05
+      }
+    });
+    const actualRows = run.predictions.filter((p) => p.actual === 0 || p.actual === 1);
+    if (!actualRows.length) continue;
+    const logistic = actualRows.map((p) => p.probs.logistic);
+    const tree = actualRows.map((p) => p.probs.tree);
+    const bt = actualRows.map((p) => p.probs.bt);
+    const ann = actualRows.map((p) => p.probs.ann);
+    const blend = actualRows.map((p) => p.probs.blended);
+    const labels = actualRows.map((p) => p.actual);
+    results.push({
+      week,
+      losses: {
+        logistic: logloss(logistic, labels),
+        tree: logloss(tree, labels),
+        bt: logloss(bt, labels),
+        ann: logloss(ann, labels),
+        blended: logloss(blend, labels)
+      }
+    });
+    const bins = run.diagnostics?.calibration_bins || [];
+    for (const b of bins) {
+      if (b.mean_pred != null && b.empirical != null && b.count > 0) {
+        calibrationPoints.push({ x: b.mean_pred, y: b.empirical });
+      }
+    }
+  }
+
+  if (!results.length) {
+    console.log("No completed weeks available for backtest.");
+    return;
+  }
+
+  const improvements = results.filter((r) => r.week >= 4 && r.losses.blended != null).map((r) => {
+    const indiv = [r.losses.logistic, r.losses.tree, r.losses.bt, r.losses.ann].filter((v) => v != null);
+    const best = Math.min(...indiv);
+    return { week: r.week, blended: r.losses.blended, best };
+  });
+
+  for (const entry of improvements) {
+    if (!(entry.blended <= entry.best * 0.99)) {
+      throw new Error(`Ensemble underperformed in week ${entry.week}: blended ${entry.blended} vs best ${entry.best}`);
+    }
+  }
+
+  const reg = regression(calibrationPoints);
+  if (Math.abs(reg.slope - 1) > 0.35 || Math.abs(reg.intercept) > 0.1) {
+    throw new Error(`Calibration drift detected: slope=${reg.slope.toFixed(2)}, intercept=${reg.intercept.toFixed(2)}`);
+  }
+
+  console.log(JSON.stringify({
+    season,
+    weeks: results.map((r) => r.week),
+    losses: results,
+    calibration: reg
+  }, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/trainer/tests/smoke.js
+++ b/trainer/tests/smoke.js
@@ -1,0 +1,89 @@
+// trainer/tests/smoke.js
+// Synthetic smoke test to ensure pipeline produces artifacts with required keys.
+
+import { runTraining } from "../train_multi.js";
+
+const teams = ["A", "B", "C", "D"];
+
+function makeGame(season, week, home, away, homeScore, awayScore) {
+  return {
+    season,
+    week,
+    game_id: `${season}-${week}-${home}-${away}`,
+    home_team: home,
+    away_team: away,
+    home_score: homeScore,
+    away_score: awayScore,
+    season_type: "REG"
+  };
+}
+
+function makeTeamRow(season, week, team, opponent, totalYards, passYards, penalties, turnovers, possession) {
+  return {
+    season,
+    week,
+    team,
+    opponent,
+    passing_yards: passYards,
+    rushing_yards: totalYards - passYards,
+    penalty_yards: penalties,
+    turnovers,
+    time_of_possession: possession,
+    def_interceptions: Math.max(0, 2 - turnovers),
+    def_fumbles: 1
+  };
+}
+
+async function main() {
+  const season = 2023;
+  const schedules = [
+    makeGame(season, 1, "A", "B", 24, 20),
+    makeGame(season, 1, "C", "D", 17, 21),
+    makeGame(season, 2, "A", "C", 30, 27),
+    makeGame(season, 2, "B", "D", 10, 14),
+    makeGame(season, 3, "A", "D", 28, 31),
+    makeGame(season, 3, "B", "C", 24, 17)
+  ];
+  const teamWeekly = [];
+  for (const game of schedules) {
+    const base = 350 + (game.week * 10);
+    teamWeekly.push(
+      makeTeamRow(season, game.week, game.home_team, game.away_team, base, base - 120, 60, 1, "30:00")
+    );
+    teamWeekly.push(
+      makeTeamRow(season, game.week, game.away_team, game.home_team, base - 30, base - 150, 45, 2, "29:30")
+    );
+  }
+
+  const result = await runTraining({
+    season,
+    week: 3,
+    data: { schedules, teamWeekly, prevTeamWeekly: [] },
+    options: {
+      btBootstrapSamples: 20,
+      annSeeds: 3,
+      annMaxEpochs: 50,
+      annCvMaxEpochs: 20,
+      annCvSeeds: 2,
+      weightStep: 0.1
+    }
+  });
+
+  if (!Array.isArray(result.predictions) || !result.predictions.length) {
+    throw new Error("Smoke test: predictions missing");
+  }
+  const sample = result.predictions[0];
+  const required = ["probs", "blend_weights", "calibration", "ci", "top_drivers", "natural_language"];
+  for (const key of required) {
+    if (!(key in sample)) throw new Error(`Smoke test: prediction missing ${key}`);
+  }
+  if (!result.modelSummary?.bt?.coefficients) throw new Error("Smoke test: BT coefficients missing");
+  if (!result.diagnostics?.metrics?.ensemble) throw new Error("Smoke test: diagnostics missing ensemble metrics");
+  if (!Array.isArray(result.btDebug) || !result.btDebug.length) throw new Error("Smoke test: btDebug missing");
+  console.log("Smoke test passed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/trainer/train_multi.js
+++ b/trainer/train_multi.js
@@ -1,389 +1,776 @@
 // trainer/train_multi.js
-// Dynamic, data-adaptive training + forecasting:
-// - hybrid weight clamp widens as more weeks of data arrive
-// - tree smoothing/complexity adapt to sample size
-// - per-game explanations; de-duplicated (home view); forecasts only for current week
+// Multi-model ensemble trainer with logistic+CART, Bradley-Terry, and ANN committee.
 
 import { loadSchedules, loadTeamWeekly } from "./dataSources.js";
 import { buildFeatures, FEATS } from "./featureBuild.js";
-import { writeFileSync, mkdirSync } from "fs";
+import { buildBTFeatures, BT_FEATURES } from "./featureBuild_bt.js";
+import { trainBTModel, predictBT, predictBTDeterministic } from "./model_bt.js";
+import { trainANNCommittee, predictANNCommittee, gradientANNCommittee } from "./model_ann.js";
 import { DecisionTreeClassifier as CART } from "ml-cart";
+import { writeFileSync, mkdirSync } from "fs";
+import { Matrix, SVD } from "ml-matrix";
 
 const ART_DIR = "artifacts";
 mkdirSync(ART_DIR, { recursive: true });
 
-const SEASON = Number(process.env.SEASON || new Date().getFullYear());
-const WEEK_ENV = Number(process.env.WEEK || 6);
+const round3 = (x) => Math.round(Number(x) * 1000) / 1000;
 
-function isReg(v){ if (v == null) return true; const s=String(v).trim().toUpperCase(); return s==="" || s.startsWith("REG"); }
-const sigmoid = z => 1/(1+Math.exp(-z));
-const dot = (a,b)=> { let s=0; for (let i=0;i<a.length;i++) s += (a[i]||0)*(b[i]||0); return s; };
-const round3 = x => Math.round(Number(x)*1000)/1000;
-const mean = a => a.length ? a.reduce((s,v)=>s+v,0)/a.length : 0;
-
-function Xy(rows){ const X = rows.map(r => FEATS.map(k => Number(r[k] ?? 0))); const y = rows.map(r => Number(r.win)); return { X, y }; }
-function splitTrainTest(all, season, week){
-  const train = all.filter(r => r.season===season && r.week <  week && (r.win===0 || r.win===1));
-  const test  = all.filter(r => r.season===season && r.week === week);
-  return { train, test };
+function matrixFromRows(rows, keys) {
+  return rows.map((row) => keys.map((k) => Number(row[k] ?? 0)));
 }
 
-function fitScaler(X){
-  const d = X[0]?.length || 0; const mu=new Array(d).fill(0), sd=new Array(d).fill(1);
-  const n = Math.max(1,X.length);
-  for (let j=0;j<d;j++){ let s=0; for (let i=0;i<X.length;i++) s+=X[i][j]; mu[j]=s/n; }
-  for (let j=0;j<d;j++){ let s=0; for (let i=0;i<X.length;i++){ const v=X[i][j]-mu[j]; s+=v*v; } sd[j]=Math.sqrt(s/n)||1; }
+function fitScaler(X) {
+  const d = X[0]?.length || 0;
+  const mu = new Array(d).fill(0);
+  const sd = new Array(d).fill(1);
+  const n = Math.max(1, X.length);
+  for (let j = 0; j < d; j++) {
+    let s = 0;
+    for (let i = 0; i < X.length; i++) s += X[i][j];
+    mu[j] = s / n;
+  }
+  for (let j = 0; j < d; j++) {
+    let s = 0;
+    for (let i = 0; i < X.length; i++) {
+      const v = X[i][j] - mu[j];
+      s += v * v;
+    }
+    sd[j] = Math.sqrt(s / n) || 1;
+  }
   return { mu, sd };
 }
-const applyScaler = (X,{mu,sd}) => X.map(r => r.map((v,j)=>(v-mu[j])/(sd[j]||1)));
 
-function trainLogisticGD(X, y, { steps=3000, lr=5e-3, l2=2e-4 } = {}){
-  const n = X.length, d = X[0]?.length || 0; let w=new Array(d).fill(0), b=0;
-  for (let t=0;t<steps;t++){
-    let gb=0; const gw=new Array(d).fill(0);
-    for (let i=0;i<n;i++){ const z=dot(w,X[i])+b, p=sigmoid(z), e=p-y[i]; gb+=e; for (let j=0;j<d;j++) gw[j]+= e*X[i][j]; }
-    for (let j=0;j<d;j++) gw[j]+= l2*w[j];
-    b -= (lr*gb/n); for (let j=0;j<d;j++) w[j] -= (lr*gw[j]/n);
+function applyScaler(X, scaler) {
+  if (!scaler) return X.map((row) => row.slice());
+  const { mu, sd } = scaler;
+  return X.map((row) => row.map((v, j) => (v - mu[j]) / (sd[j] || 1)));
+}
+
+const sigmoid = (z) => 1 / (1 + Math.exp(-z));
+
+function trainLogisticGD(X, y, { steps = 3000, lr = 5e-3, l2 = 2e-4 } = {}) {
+  const n = X.length;
+  const d = X[0]?.length || 0;
+  let w = new Array(d).fill(0);
+  let b = 0;
+  if (!n || !d) return { w, b };
+  for (let t = 0; t < steps; t++) {
+    let gb = 0;
+    const gw = new Array(d).fill(0);
+    for (let i = 0; i < n; i++) {
+      const z = X[i].reduce((s, v, idx) => s + v * w[idx], 0) + b;
+      const p = sigmoid(z);
+      const err = p - y[i];
+      gb += err;
+      for (let j = 0; j < d; j++) gw[j] += err * X[i][j];
+    }
+    gb /= Math.max(1, n);
+    for (let j = 0; j < d; j++) gw[j] = gw[j] / Math.max(1, n) + l2 * w[j];
+    b -= lr * gb;
+    for (let j = 0; j < d; j++) w[j] -= lr * gw[j];
   }
   return { w, b };
 }
-const predictLogit = (X,{w,b}) => X.map(x => sigmoid(dot(w,x)+b));
 
-// ---- Decision tree helpers (adaptive smoothing / complexity) ----
-function leafPath(root, x){
-  let node=root, path="";
-  for (let guard=0; guard<200; guard++){
-    const isLeaf = (!node.left && !node.right) || node.type==="leaf";
-    if (isLeaf) return path||"ROOT";
-    const col = node.splitColumn ?? node.attribute ?? node.index ?? node.feature ?? null;
-    const thr = node.splitValue  ?? node.threshold ?? node.split  ?? null;
-    if (col==null || thr==null) return path||"ROOT";
-    const val = Number(x[col]??0); const goLeft = val <= Number(thr);
-    path += goLeft ? "L":"R"; node = goLeft ? node.left : node.right; if (!node) return path;
+const predictLogit = (X, model) => X.map((row) => sigmoid(row.reduce((s, v, idx) => s + v * model.w[idx], 0) + model.b));
+
+function leafPath(root, x) {
+  let node = root;
+  let path = "";
+  for (let guard = 0; guard < 256; guard++) {
+    if (!node) return path || "ROOT";
+    if (!node.left && !node.right) return path || "ROOT";
+    const col = node.splitColumn ?? node.attribute ?? node.index ?? node.feature;
+    const thr = node.splitValue ?? node.threshold ?? node.split;
+    if (col == null || thr == null) return path || "ROOT";
+    const val = Number(x[col] ?? 0);
+    const goLeft = val <= Number(thr);
+    path += goLeft ? "L" : "R";
+    node = goLeft ? node.left : node.right;
   }
-  return path||"ROOT";
+  return path || "ROOT";
 }
-function buildLeafFreq(cart, Xtr, ytr, alpha){
-  let json; try { json=cart.toJSON(); } catch { json=null; }
-  const root = json?.root || json; const freq=new Map();
-  if (!root){
-    const n1=ytr.reduce((s,v)=>s+(v?1:0),0), n0=ytr.length-n1;
-    freq.set("ROOT",{n0,n1,alpha});
-    return {root:null,freq,alpha};
+
+function buildLeafFreq(cart, Xtr, ytr, alpha) {
+  let json;
+  try {
+    json = cart.toJSON();
+  } catch (e) {
+    json = null;
   }
-  for (let i=0;i<Xtr.length;i++){
-    const p=leafPath(root,Xtr[i]); const f=freq.get(p)||{n0:0,n1:0,alpha};
-    if (ytr[i]===1) f.n1++; else f.n0++; freq.set(p,f);
+  const root = json?.root || json;
+  const freq = new Map();
+  if (!root) {
+    const n1 = ytr.reduce((s, v) => s + (v ? 1 : 0), 0);
+    const n0 = ytr.length - n1;
+    freq.set("ROOT", { n0, n1, alpha });
+    return { root: null, freq, alpha };
+  }
+  for (let i = 0; i < Xtr.length; i++) {
+    const p = leafPath(root, Xtr[i]);
+    const rec = freq.get(p) || { n0: 0, n1: 0, alpha };
+    if (ytr[i] === 1) rec.n1 += 1;
+    else rec.n0 += 1;
+    freq.set(p, rec);
   }
   return { root, freq, alpha };
 }
-function predictTree(cart, leafStats, X){
+
+function predictTree(cart, leafStats, X) {
   const { root, freq, alpha } = leafStats;
-  if (!root){
-    const f=freq.get("ROOT")||{n0:0,n1:0,alpha:4}; const tot=f.n0+f.n1; const p1=(f.n1+alpha)/(tot+2*alpha)||0.5;
-    return X.map(()=>p1);
+  if (!root) {
+    const rec = freq.get("ROOT") || { n0: 0, n1: 0, alpha: 4 };
+    const tot = rec.n0 + rec.n1;
+    const p1 = (rec.n1 + rec.alpha) / (tot + 2 * rec.alpha);
+    return X.map(() => p1);
   }
-  return X.map(x=>{
-    const p=leafPath(root,x); const f=freq.get(p);
-    if (!f){ return 0.5; }
-    const tot=f.n0+f.n1; return (f.n1 + alpha)/(tot + 2*alpha);
+  return X.map((x) => {
+    const path = leafPath(root, x);
+    const rec = freq.get(path);
+    if (!rec) return 0.5;
+    const tot = rec.n0 + rec.n1;
+    return (rec.n1 + alpha) / (tot + 2 * alpha);
   });
 }
 
-// ---- Hybrid weight via CV, with adaptive clamp based on #weeks ----
-function kfoldIndices(n, k=5){
-  const idx = Array.from({length:n}, (_,i)=>i);
-  const folds = Array.from({length:k}, ()=>[]);
-  for (let i=0;i<n;i++) folds[i%k].push(idx[i]);
+function chooseTreeParams(n) {
+  const depth = Math.min(6, Math.max(3, Math.floor(2 + Math.log2(Math.max(16, n || 1)))));
+  const minSamples = Math.min(32, Math.max(8, Math.floor(Math.max(8, (n || 1) / 18))));
+  return { depth, minSamples };
+}
+
+function laplaceAlpha(n) {
+  const approxWeeks = Math.max(2, Math.min(8, Math.round((n || 1) / 32)));
+  return Math.max(2, Math.round(10 - 2 * approxWeeks));
+}
+
+function kfoldIndices(n, k) {
+  if (n <= 1) return [[...Array(n).keys()]];
+  const folds = Array.from({ length: k }, () => []);
+  for (let i = 0; i < n; i++) {
+    folds[i % k].push(i);
+  }
   return folds;
 }
-function chooseHybridCV(X, y){
-  const folds = kfoldIndices(X.length, Math.min(5, Math.max(2, Math.floor(X.length/8))));
-  const weights = Array.from({length:21}, (_,i)=> i*0.05);
-  const losses = new Array(weights.length).fill(0);
-  for (const valIdx of folds){
-    const trainIdx = new Set(Array.from({length:X.length},(_,i)=>i).filter(i=>!valIdx.includes(i)));
-    const Xtr = [], ytr = [], Xva = [], yva = [];
-    for (let i=0;i<X.length;i++){
-      if (trainIdx.has(i)){ Xtr.push(X[i]); ytr.push(y[i]); } else { Xva.push(X[i]); yva.push(y[i]); }
-    }
-    const scaler = fitScaler(Xtr);
-    const XtrS = applyScaler(Xtr, scaler);
-    const XvaS = applyScaler(Xva, scaler);
 
-    const pos = ytr.reduce((s,v)=>s+(v?1:0),0); const neg = ytr.length - pos;
-    let logit;
-    if (pos===0 || neg===0){
-      const prior = pos/Math.max(1,pos+neg);
-      const b = Math.log((prior+1e-9)/(1-prior+1e-9));
-      logit = { w: new Array(XtrS[0].length).fill(0), b };
-    } else {
-      logit = trainLogisticGD(XtrS, ytr, { steps: 3000, lr: 5e-3, l2: 2e-4 });
-    }
+const logloss = (probs, labels) => {
+  if (!labels.length) return null;
+  let s = 0;
+  const eps = 1e-12;
+  for (let i = 0; i < labels.length; i++) {
+    const p = Math.min(Math.max(probs[i], eps), 1 - eps);
+    s += -(labels[i] * Math.log(p) + (1 - labels[i]) * Math.log(1 - p));
+  }
+  return s / labels.length;
+};
 
-    // Adaptive tree complexity: deeper with more data; more conservative early
-    const depth = Math.min(6, Math.max(4, Math.floor(2 + Math.log2(Math.max(16, XtrS.length))))); // ~4..6
-    const minSamples = Math.min(24, Math.max(8, Math.floor(XtrS.length / 20))); // ~8..24
-    const cart = new CART({ maxDepth: depth, minNumSamples: minSamples, gainFunction: "gini" });
+const brier = (probs, labels) => {
+  if (!labels.length) return null;
+  let s = 0;
+  for (let i = 0; i < labels.length; i++) {
+    const diff = probs[i] - labels[i];
+    s += diff * diff;
+  }
+  return s / labels.length;
+};
 
-    cart.train(XtrS, ytr);
-
-    // Adaptive Laplace α: higher when fewer weeks (stronger smoothing early)
-    // α ≈ 6 at 2 weeks, ≈4 at 3 weeks, → 2 by 5+ weeks
-    const approxWeeks = Math.max(2, Math.min(8, Math.round(XtrS.length / 32)));
-    const alpha = Math.max(2, Math.round(10 - 2*approxWeeks));
-    const leafStats = buildLeafFreq(cart, XtrS, ytr, alpha);
-
-    const pL = predictLogit(XvaS, logit);
-    const pT = predictTree(cart, leafStats, XvaS);
-    for (let wi=0; wi<weights.length; wi++){
-      const w = weights[wi];
-      let ll=0, eps=1e-12;
-      for (let i=0;i<XvaS.length;i++){
-        const ph = w*pL[i] + (1-w)*pT[i];
-        ll += -(yva[i]*Math.log(Math.max(ph,eps)) + (1-yva[i])*Math.log(Math.max(1-ph,eps)));
-      }
-      losses[wi] += ll / Math.max(1,XvaS.length);
+function auc(probs, labels) {
+  const pairs = probs.map((p, i) => ({ p, y: labels[i] }));
+  const pos = pairs.filter((r) => r.y === 1);
+  const neg = pairs.filter((r) => r.y === 0);
+  if (!pos.length || !neg.length) return null;
+  let wins = 0;
+  let ties = 0;
+  for (const a of pos) {
+    for (const b of neg) {
+      if (a.p > b.p) wins += 1;
+      else if (a.p === b.p) ties += 1;
     }
   }
-  let bestW = 0.5, bestL = Infinity;
-  weights.forEach((w,i)=>{ if (losses[i] < bestL){ bestL = losses[i]; bestW = w; } });
-  return Number(bestW.toFixed(2));
+  return (wins + 0.5 * ties) / (pos.length * neg.length);
 }
 
-// ---- NL helpers ----
-function leagueMeans(rows){ const m={}; for (const k of FEATS){ m[k]=mean(rows.map(r=>Number(r[k]||0))); } return m; }
-function gamesPlayed(r){ const w=Number(r.wins_s2d||0), l=Number(r.losses_s2d||0); return Math.max(1, w+l); }
-function explain(r, probs, means){
-  const lines=[];
-  const add=(key, lowIsGood, label)=>{
-    const gp = gamesPlayed(r);
-    const v=Number(r[key])/gp, m=Number(means[key])/gp;
-    if (!Number.isFinite(v)||!Number.isFinite(m)) return;
-    const d=v-m, dir = d>=0?"higher":"lower"; const good = lowIsGood ? d<0 : d>0;
-    lines.push(`${label} per game is ${dir} than league average by ${Math.abs(d).toFixed(1)} (${good?"good":"needs attention"}).`);
-  };
-  add("def_turnovers_s2d", false, "Defensive takeaways");
-  add("off_turnovers_s2d", true,  "Offensive giveaways");
-  add("off_total_yds_s2d", false, "Offensive total yards");
-  add("def_total_yds_s2d", true,  "Yards allowed");
-  if (r.home) lines.push("Home-field advantage applies.");
-  const rd=Number(r.rest_diff); if (Number.isFinite(rd)&&Math.abs(rd)>=2){ lines.push(`Rest edge: ${rd>=0?"+":""}${rd} day(s).`); }
-  return `Logistic: ${(probs.logit*100).toFixed(1)}%. Tree: ${(probs.tree*100).toFixed(1)}%. Hybrid: ${(probs.hybrid*100).toFixed(1)}%. `+lines.join(" ");
+function calibrationBins(probs, labels, bins = 10) {
+  if (!labels.length) return [];
+  const binCounts = Array.from({ length: bins }, () => ({ sum: 0, count: 0, actual: 0 }));
+  for (let i = 0; i < labels.length; i++) {
+    const idx = Math.min(bins - 1, Math.max(0, Math.floor(probs[i] * bins)));
+    binCounts[idx].sum += probs[i];
+    binCounts[idx].actual += labels[i];
+    binCounts[idx].count += 1;
+  }
+  return binCounts.map((b, idx) => ({
+    lower: idx / bins,
+    upper: (idx + 1) / bins,
+    mean_pred: b.count ? b.sum / b.count : null,
+    empirical: b.count ? b.actual / b.count : null,
+    count: b.count
+  }));
 }
-function toResult(r, probs, forecast, wHybrid, trainRows){
-  const means = leagueMeans(trainRows);
+
+function enumerateWeights(step = 0.05) {
+  const weights = [];
+  for (let wl = 0; wl <= 1; wl += step) {
+    for (let wt = 0; wt <= 1 - wl; wt += step) {
+      for (let wb = 0; wb <= 1 - wl - wt; wb += step) {
+        const wa = 1 - wl - wt - wb;
+        if (wa < -1e-9) continue;
+        weights.push({ logistic: wl, tree: wt, bt: wb, ann: wa });
+      }
+    }
+  }
+  return weights;
+}
+
+function clampWeights(weights, weeks) {
+  const w = { ...weights };
+  if (weeks < 4) w.ann *= 0.5;
+  if (weeks < 3) w.logistic *= 0.8;
+  const total = w.logistic + w.tree + w.bt + w.ann;
+  if (!total) return { logistic: 0.25, tree: 0.25, bt: 0.25, ann: 0.25 };
   return {
-    game_id: `${r.season}-W${String(r.week).padStart(2,"0")}-${r.team}-${r.opponent}`,
-    home_team: r.home ? r.team : r.opponent,
-    away_team: r.home ? r.opponent : r.team,
-    season: r.season,
-    week: r.week,
-    forecast,
-    models: {
-      logistic:      { prob_win: round3(probs.logit) },
-      decision_tree: { prob_win: round3(probs.tree) },
-      hybrid:        { prob_win: round3(probs.hybrid), weights: { logistic: wHybrid, tree: Number((1-wHybrid).toFixed(2)) } }
-    },
-    natural_language: explain(r, probs, means)
+    logistic: w.logistic / total,
+    tree: w.tree / total,
+    bt: w.bt / total,
+    ann: w.ann / total
   };
 }
 
-// ---- Forecast missing fixtures in target week using last known S2D ----
-function forecastMissingForWeek(W, regSched, SEASON, trainRows, testRows){
-  const presentPairs = new Set(testRows.map(r => (r.home ? `${r.team}@${r.opponent}` : `${r.opponent}@${r.team}`)));
-  const regPairs = regSched.filter(g=>Number(g.week)===W).map(g => `${g.home_team}@${g.away_team}`);
-  const missing = regPairs.filter(k => !presentPairs.has(k));
-  if (!missing.length) return [];
-
-  const lastByTeam = new Map();
-  for (const r of trainRows){
-    if (r.season!==SEASON) continue;
-    const prev = lastByTeam.get(r.team);
-    if (!prev || r.week > prev.week) lastByTeam.set(r.team, r);
+function plattCalibrate(probs, labels) {
+  if (!labels.length) return { beta: 0 };
+  const logits = probs.map((p) => {
+    const eps = 1e-12;
+    const v = Math.min(Math.max(p, eps), 1 - eps);
+    return Math.log(v / (1 - v));
+  });
+  let beta = 0;
+  for (let iter = 0; iter < 200; iter++) {
+    let grad = 0;
+    let hess = 0;
+    for (let i = 0; i < labels.length; i++) {
+      const z = logits[i] + beta;
+      const p = 1 / (1 + Math.exp(-z));
+      grad += p - labels[i];
+      hess += p * (1 - p);
+    }
+    if (Math.abs(grad) < 1e-6) break;
+    beta -= grad / Math.max(1e-6, hess);
   }
-
-  const rows = [];
-  for (const m of missing){
-    const [home, away] = m.split("@");
-    const hPrev = lastByTeam.get(home);
-    const aPrev = lastByTeam.get(away);
-    if (!hPrev || !aPrev) continue;
-
-    const clone = (src, team, opp, isHome) => {
-      const r = { season: SEASON, week: W, team, opponent: opp, home: isHome?1:0, game_date: null, win: null };
-      for (const f of FEATS){
-        if (f === "home") { r.home = isHome?1:0; continue; }
-        r[f] = Number(src[f] ?? 0);
-      }
-      const me = r, op = isHome ? aPrev : hPrev;
-      me.off_total_yds_s2d_minus_opp = Number(me.off_total_yds_s2d) - Number(op.off_total_yds_s2d);
-      me.def_total_yds_s2d_minus_opp = Number(me.def_total_yds_s2d) - Number(op.def_total_yds_s2d);
-      me.off_turnovers_s2d_minus_opp = Number(me.off_turnovers_s2d)  - Number(op.off_turnovers_s2d);
-      me.def_turnovers_s2d_minus_opp = Number(me.def_turnovers_s2d)  - Number(op.off_turnovers_s2d);
-      return r;
-    };
-    rows.push(clone(hPrev, home, away, true));
-    rows.push(clone(aPrev, away, home, false));
-  }
-  return rows;
+  return { beta };
 }
 
-// ---- De-duplicate to one row per matchup (home view) ----
-function dedupeToHomeView(items) {
-  const seen = new Set(); const out = [];
-  for (const r of items) {
-    const key = `${r.season}-W${String(r.week).padStart(2,'0')}-${r.home_team}-${r.away_team}`;
-    if (!seen.has(key)) { seen.add(key); out.push(r); }
+function applyPlatt(prob, calibrator) {
+  const eps = 1e-12;
+  const v = Math.min(Math.max(prob, eps), 1 - eps);
+  const logit = Math.log(v / (1 - v));
+  const z = logit + (calibrator?.beta ?? 0);
+  return 1 / (1 + Math.exp(-z));
+}
+
+function computePCA(X, featureNames, top = 5) {
+  if (!X?.length) return [];
+  try {
+    const mat = new Matrix(X);
+    const svd = new SVD(mat, { computeLeftSingularVectors: false, autoTranspose: true });
+    const V = svd.rightSingularVectors;
+    const diag = svd.diagonal;
+    const total = diag.reduce((s, v) => s + v * v, 0) || 1;
+    const comps = [];
+    for (let i = 0; i < Math.min(top, diag.length); i++) {
+      const vec = V.getColumn(i);
+      const loadings = featureNames.map((f, idx) => ({ feature: f, loading: vec[idx] }));
+      loadings.sort((a, b) => Math.abs(b.loading) - Math.abs(a.loading));
+      comps.push({
+        component: i + 1,
+        explained_variance: (diag[i] * diag[i]) / total,
+        top_loadings: loadings.slice(0, 10)
+      });
+    }
+    return comps;
+  } catch (e) {
+    return [];
   }
+}
+
+const FEATURE_LABELS = {
+  off_turnovers_s2d: "offensive turnovers",
+  def_turnovers_s2d: "defensive takeaways",
+  off_total_yds_s2d: "offense yards",
+  def_total_yds_s2d: "yards allowed",
+  rest_diff: "rest advantage",
+  diff_total_yards: "total yards differential",
+  diff_penalty_yards: "penalty yards differential",
+  diff_turnovers: "turnover differential",
+  diff_possession_seconds: "possession differential",
+  diff_r_ratio: "r-ratio differential",
+  delta_power_rank: "power rating delta"
+};
+
+function humanizeFeature(key) {
+  return FEATURE_LABELS[key] || key;
+}
+
+function describeDiff(value, label, goodHigh = true, unit = "") {
+  const diff = Number(value || 0);
+  const sign = diff > 0 ? "+" : diff < 0 ? "" : "±";
+  const absVal = Math.abs(diff).toFixed(2);
+  const direction = diff === 0 ? "even" : diff > 0 ? "edge" : "deficit";
+  const framing = diff === 0 ? "balanced" : diff > 0 === goodHigh ? "favorable" : "needs attention";
+  const suffix = unit ? `${absVal}${unit}` : absVal;
+  return `${label} ${direction} ${sign}${suffix} (${framing})`;
+}
+
+function buildNarrative(game, probs, btFeatures) {
+  const items = [
+    { key: "diff_turnovers", label: "Turnovers", goodHigh: true },
+    { key: "diff_r_ratio", label: "R-ratio", goodHigh: true },
+    { key: "diff_penalty_yards", label: "Penalty yards", goodHigh: false },
+    { key: "diff_total_yards", label: "Total yards", goodHigh: true },
+    { key: "diff_possession_seconds", label: "Possession time", goodHigh: true }
+  ];
+  items.sort((a, b) => Math.abs(btFeatures[b.key] ?? 0) - Math.abs(btFeatures[a.key] ?? 0));
+  const statements = items.slice(0, 3).map((item) => describeDiff(btFeatures[item.key], item.label, item.goodHigh));
+  return `${game.home_team} vs ${game.away_team}: logistic ${round3(probs.logistic * 100)}%, tree ${round3(probs.tree * 100)}%, BT ${round3(probs.bt * 100)}%, ANN ${round3(probs.ann * 100)}%, blended ${round3(probs.blended * 100)}%. Key drivers: ${statements.join("; ")}.`;
+}
+
+function buildTopDrivers({ logisticContribs, treeInfo, btContribs, annGrad }) {
+  const drivers = [];
+  logisticContribs
+    .map((v) => ({ feature: humanizeFeature(v.feature), direction: v.value >= 0 ? "positive" : "negative", magnitude: Math.abs(v.value), source: "logit" }))
+    .sort((a, b) => b.magnitude - a.magnitude)
+    .slice(0, 3)
+    .forEach((d) => drivers.push(d));
+  if (treeInfo) {
+    drivers.push({
+      feature: `CART leaf ${treeInfo.path}`,
+      direction: treeInfo.winrate >= 0.5 ? "positive" : "negative",
+      magnitude: Math.abs(treeInfo.winrate - 0.5),
+      source: "tree"
+    });
+  }
+  btContribs
+    .map((v) => ({ feature: humanizeFeature(v.feature), direction: v.value >= 0 ? "positive" : "negative", magnitude: Math.abs(v.value), source: "bt" }))
+    .sort((a, b) => b.magnitude - a.magnitude)
+    .slice(0, 2)
+    .forEach((d) => drivers.push(d));
+  annGrad
+    .map((v) => ({ feature: humanizeFeature(v.feature), direction: v.value >= 0 ? "positive" : "negative", magnitude: Math.abs(v.value), source: "ann" }))
+    .sort((a, b) => b.magnitude - a.magnitude)
+    .slice(0, 2)
+    .forEach((d) => drivers.push(d));
+  return drivers;
+}
+
+function defaultWeights() {
+  return { logistic: 0.25, tree: 0.25, bt: 0.25, ann: 0.25 };
+}
+
+function ensureArray(arr, len, fill = 0.5) {
+  if (arr.length === len) return arr;
+  const out = new Array(len).fill(fill);
+  for (let i = 0; i < Math.min(len, arr.length); i++) out[i] = arr[i];
   return out;
 }
 
-(async function main(){
-  console.log(`Rolling train for SEASON=${SEASON} (env WEEK=${WEEK_ENV})`);
+const makeGameId = (row) =>
+  `${row.season}-W${String(row.week).padStart(2, "0")}-${row.team}-${row.opponent}`;
 
-  const schedules = await loadSchedules();
-  const teamWeekly = await loadTeamWeekly(SEASON);
-  const prevTeamWeekly = await (async()=>{ try { return await loadTeamWeekly(SEASON-1); } catch { return []; } })();
+export async function runTraining({ season, week, data = {}, options = {} } = {}) {
+  const resolvedSeason = Number(season ?? process.env.SEASON ?? new Date().getFullYear());
+  let resolvedWeek = Number(week ?? process.env.WEEK ?? 6);
+  if (!Number.isFinite(resolvedWeek)) resolvedWeek = 6;
 
-  const regSched = schedules.filter(g => Number(g.season)===SEASON && isReg(g.season_type));
-  const schedWeeks = [...new Set(regSched.map(g => Number(g.week)).filter(Number.isFinite))].sort((a,b)=>a-b);
-  const maxSchedWeek = schedWeeks.length ? schedWeeks[schedWeeks.length-1] : 18;
-
-  // last full regular-season week (all games final)
-  function hasFinalScore(g){
-    const hs = Number(g.home_score ?? g.home_points ?? g.home_pts);
-    const as = Number(g.away_score ?? g.away_points ?? g.away_pts);
-    return Number.isFinite(hs) && Number.isFinite(as);
-  }
-  let lastFull = 0;
-  for (const w of schedWeeks){
-    const games = regSched.filter(g=>Number(g.week)===w);
-    const allFinal = games.length>0 && games.every(hasFinalScore);
-    if (allFinal) lastFull = w; else break;
-  }
-
-  // Build features from actual data (weeks that exist in team-week CSV)
-  const featRows = buildFeatures({ teamWeekly, schedules, season: SEASON, prevTeamWeekly });
-  const dataWeeks = [...new Set(featRows.map(r=>r.week))].sort((a,b)=>a-b);
-  console.log(`Built feature rows: ${featRows.length} | data weeks: ${JSON.stringify(dataWeeks)}`);
-
-  // Cap through current week (lastFull + 1), never beyond WEEK_ENV or schedule cap.
-  const CURRENT_WEEK = Math.min(lastFull + 1, maxSchedWeek);
-  const MAX_WEEK = Math.min(WEEK_ENV, CURRENT_WEEK);
-  console.log(`Train/predict through WEEK ${MAX_WEEK} (env=${WEEK_ENV}, current=${CURRENT_WEEK}, lastFull=${lastFull}, schedMax=${maxSchedWeek})`);
-
-  const seasonSummary = { season: SEASON, built_through_week: null, weeks: [], feature_names: FEATS };
-  const seasonIndex = { season: SEASON, weeks: [] };
-  let latestWeekWritten = null;
-
-  function runWeek(W){
-    const { train, test } = splitTrainTest(featRows, SEASON, W);
-    const weeksSeen = [...new Set(train.map(r=>r.week))].length;
-    const pos = train.reduce((s,r)=> s+(r.win?1:0),0);
-    const neg = train.length - pos;
-    console.log(`W${W}: train rows=${train.length} weeks_seen=${weeksSeen} pos=${pos} neg=${neg} pos_rate=${train.length?(pos/train.length).toFixed(3):"n/a"}`);
-    if (!train.length) return null;
-
-    const { X: XtrRaw } = Xy(train);
-    const ytr = train.map(r=>r.win);
-    const scaler = fitScaler(XtrRaw);
-    const Xtr = applyScaler(XtrRaw, scaler);
-
-    // logistic
-    let logit;
-    if (pos===0 || neg===0){
-      const prior = pos/Math.max(1,pos+neg);
-      const b = Math.log((prior+1e-9)/(1-prior+1e-9));
-      logit = { w: new Array(Xtr[0].length).fill(0), b };
-      console.log(`W${W}: logistic prior-only (single class), prior=${prior.toFixed(3)}`);
-    } else {
-      logit = trainLogisticGD(Xtr, ytr, { steps: 3500, lr: 4e-3, l2: 2e-4 });
+  const schedules = data.schedules ?? (await loadSchedules());
+  const teamWeekly = data.teamWeekly ?? (await loadTeamWeekly(resolvedSeason));
+  let prevTeamWeekly;
+  if (data.prevTeamWeekly !== undefined) {
+    prevTeamWeekly = data.prevTeamWeekly;
+  } else {
+    try {
+      prevTeamWeekly = await loadTeamWeekly(resolvedSeason - 1);
+    } catch (e) {
+      prevTeamWeekly = [];
     }
-
-    // Adaptive tree complexity
-    const depth = Math.min(6, Math.max(4, 3 + Math.ceil(weeksSeen/2)));      // 4..6
-    const minSamples = Math.min(24, Math.max(8, Math.floor(Xtr.length/20))); // 8..24
-    const cart = new CART({ maxDepth: depth, minNumSamples: minSamples, gainFunction: "gini" });
-    cart.train(Xtr, ytr);
-
-    // Adaptive Laplace α (strong early, lighter later)
-    const alpha = weeksSeen <= 3 ? 6 : (weeksSeen === 4 ? 3 : 2);
-    const leafStats = buildLeafFreq(cart, Xtr, ytr, alpha);
-
-    // hybrid by CV, then adaptive clamp based on weeks seen
-    const wCV = chooseHybridCV(Xtr, ytr);
-    let [lo, hi] = (()=>{
-      if (weeksSeen <= 3) return [0.35, 0.65];
-      if (weeksSeen === 4) return [0.25, 0.75];
-      return [0.0, 1.0]; // 5+ weeks: no clamp
-    })();
-    let wHybrid = Math.min(hi, Math.max(lo, wCV));
-    wHybrid = Number(wHybrid.toFixed(2));
-    console.log(`W${W}: hybrid_cv=${wCV.toFixed(2)} clamp=[${lo.toFixed(2)},${hi.toFixed(2)}] -> hybrid=${wHybrid.toFixed(2)} depth=${depth} minSamples=${minSamples} alpha=${alpha}`);
-
-    // backtest on observed rows of W
-    const { X: XteRaw } = Xy(test);
-    const Xte = applyScaler(XteRaw, scaler);
-    const pL_back = predictLogit(Xte, logit);
-    const pT_back = predictTree(cart, leafStats, Xte);
-    const pH_back = pL_back.map((p,i)=> wHybrid*p + (1-wHybrid)*pT_back[i]);
-    const back = test.map((r,i)=> toResult(r, { logit:pL_back[i], tree:pT_back[i], hybrid:pH_back[i] }, false, wHybrid, train));
-
-    // forecast rest of week W
-    const foreRows = forecastMissingForWeek(W, regSched, SEASON, train, test);
-    const { X: XfRaw } = Xy(foreRows);
-    const Xf = applyScaler(XfRaw, scaler);
-    const pL_f = predictLogit(Xf, logit);
-    const pT_f = predictTree(cart, leafStats, Xf);
-    const pH_f = pL_f.map((p,i)=> wHybrid*p + (1-wHybrid)*pT_f[i]);
-    const fore = foreRows.map((r,i)=> toResult(r, { logit:pL_f[i], tree:pT_f[i], hybrid:pH_f[i] }, true, wHybrid, train));
-
-    return { results: [...back, ...fore], scaler, wHybrid, logit };
   }
 
-  for (let W=2; W<=MAX_WEEK; W++){
-    const res = runWeek(W);
-    if (!res) continue;
-    const { results, scaler, wHybrid, logit } = res;
+  const featureRows = buildFeatures({ teamWeekly, schedules, season: resolvedSeason, prevTeamWeekly });
+  const btRows = buildBTFeatures({ teamWeekly, schedules, season: resolvedSeason, prevTeamWeekly });
 
-    const resultsDeduped = dedupeToHomeView(results);
+  const btTrainRowsRaw = btRows.filter(
+    (r) => r.season === resolvedSeason && r.week < resolvedWeek && (r.label_win === 0 || r.label_win === 1)
+  );
+  const btTestRowsRaw = btRows.filter((r) => r.season === resolvedSeason && r.week === resolvedWeek);
 
-    const predPath  = `${ART_DIR}/predictions_${SEASON}_W${String(W).padStart(2,"0")}.json`;
-    const modelPath = `${ART_DIR}/model_${SEASON}_W${String(W).padStart(2,"0")}.json`;
-    writeFileSync(predPath, JSON.stringify(resultsDeduped, null, 2));
-    writeFileSync(modelPath, JSON.stringify({
-      season: SEASON, week: W, features: FEATS, hybrid_weight: wHybrid,
-      logistic: { weights: logit.w, intercept: logit.b }, scaler
-    }, null, 2));
-    console.log(`WROTE: ${predPath}`);
-    console.log(`WROTE: ${modelPath}`);
+  const btTrainMap = new Map(btTrainRowsRaw.map((r) => [r.game_id, r]));
+  const btTestMap = new Map(btTestRowsRaw.map((r) => [r.game_id, r]));
 
-    seasonSummary.weeks.push({
-      week: W,
-      train_rows: resultsDeduped.filter(r=>!r.forecast).length,
-      forecast: resultsDeduped.some(r=>r.forecast),
-      hybrid_weight: wHybrid
+  const trainRowsRaw = featureRows.filter(
+    (r) => r.season === resolvedSeason && r.week < resolvedWeek && r.home === 1 && (r.win === 0 || r.win === 1)
+  );
+  const testRowsRaw = featureRows.filter(
+    (r) => r.season === resolvedSeason && r.week === resolvedWeek && r.home === 1
+  );
+
+  const trainGames = trainRowsRaw
+    .map((row) => ({ row, bt: btTrainMap.get(makeGameId(row)) }))
+    .filter((g) => g.bt);
+  const testGames = testRowsRaw
+    .map((row) => ({ row, bt: btTestMap.get(makeGameId(row)) }))
+    .filter((g) => g.bt);
+
+  const trainRows = trainGames.map((g) => g.row);
+  const btTrainRows = trainGames.map((g) => g.bt);
+  const testRows = testGames.map((g) => g.row);
+  const btTestRows = testGames.map((g) => g.bt);
+
+  const labels = trainRows.map((r) => Number(r.win));
+  const weeksSeen = new Set(trainRows.map((r) => r.week)).size;
+  const trainMatrix = matrixFromRows(trainRows, FEATS);
+  const scaler = fitScaler(trainMatrix.length ? trainMatrix : [new Array(FEATS.length).fill(0)]);
+  const trainStd = applyScaler(trainMatrix, scaler);
+
+  const nTrain = trainRows.length;
+  let folds = [];
+  let oofLogit = [];
+  let oofTree = [];
+  if (nTrain >= 2) {
+    const k = Math.min(5, Math.max(2, Math.floor(nTrain / 6)));
+    folds = kfoldIndices(nTrain, k);
+    oofLogit = new Array(nTrain).fill(0.5);
+    oofTree = new Array(nTrain).fill(0.5);
+    for (const valIdx of folds) {
+      const trainIdx = new Set(Array.from({ length: nTrain }, (_, i) => i).filter((i) => !valIdx.includes(i)));
+      const Xtr = [];
+      const ytr = [];
+      const Xva = [];
+      const iva = [];
+      for (let i = 0; i < nTrain; i++) {
+        if (trainIdx.has(i)) {
+          Xtr.push(trainMatrix[i]);
+          ytr.push(labels[i]);
+        } else {
+          Xva.push(trainMatrix[i]);
+          iva.push(i);
+        }
+      }
+      const scalerFold = fitScaler(Xtr.length ? Xtr : [new Array(FEATS.length).fill(0)]);
+      const XtrS = applyScaler(Xtr, scalerFold);
+      const XvaS = applyScaler(Xva, scalerFold);
+      const logitModel = trainLogisticGD(XtrS, ytr, { steps: 2500, lr: 4e-3, l2: 2e-4 });
+      const params = chooseTreeParams(XtrS.length);
+      const cart = new CART({ maxDepth: params.depth, minNumSamples: params.minSamples, gainFunction: "gini" });
+      if (XtrS.length) cart.train(XtrS, ytr);
+      const leafStats = buildLeafFreq(cart, XtrS, ytr, laplaceAlpha(XtrS.length));
+      const pLog = predictLogit(XvaS, logitModel);
+      const pTree = predictTree(cart, leafStats, XvaS);
+      for (let j = 0; j < iva.length; j++) {
+        oofLogit[iva[j]] = pLog[j];
+        oofTree[iva[j]] = pTree[j];
+      }
+    }
+  } else {
+    oofLogit = ensureArray([], nTrain, 0.5);
+    oofTree = ensureArray([], nTrain, 0.5);
+  }
+
+  const annSeeds = options.annSeeds ?? Number(process.env.ANN_SEEDS ?? 15);
+  const annMaxEpochs = options.annMaxEpochs ?? Number(process.env.ANN_MAX_EPOCHS ?? 200);
+  const annCvSeeds = Math.max(3, Math.min(annSeeds, options.annCvSeeds ?? 5));
+  const annOOF = new Array(nTrain).fill(0.5);
+  if (nTrain >= 2) {
+    const foldSets = folds.length ? folds : [Array.from({ length: nTrain }, (_, i) => i)];
+    for (const valIdx of foldSets) {
+      const trainIdx = new Set(Array.from({ length: nTrain }, (_, i) => i).filter((i) => !valIdx.includes(i)));
+      const Xtr = [];
+      const ytr = [];
+      const Xva = [];
+      const iva = [];
+      for (let i = 0; i < nTrain; i++) {
+        if (trainIdx.has(i)) {
+          Xtr.push(trainMatrix[i]);
+          ytr.push(labels[i]);
+        } else {
+          Xva.push(trainMatrix[i]);
+          iva.push(i);
+        }
+      }
+      const scalerFold = fitScaler(Xtr.length ? Xtr : [new Array(FEATS.length).fill(0)]);
+      const XtrS = applyScaler(Xtr, scalerFold);
+      const XvaS = applyScaler(Xva, scalerFold);
+      const annModel = trainANNCommittee(XtrS, ytr, {
+        seeds: annCvSeeds,
+        maxEpochs: Math.min(annMaxEpochs, options.annCvMaxEpochs ?? 120),
+        lr: 1e-3,
+        patience: 8,
+        timeLimitMs: options.annCvTimeLimit ?? 20000
+      });
+      const preds = predictANNCommittee(annModel, XvaS);
+      for (let j = 0; j < iva.length; j++) annOOF[iva[j]] = preds[j];
+    }
+  }
+
+  const btOOF = new Array(nTrain).fill(0.5);
+  if (btTrainRows.length && nTrain) {
+    const foldSets = folds.length ? folds : [Array.from({ length: nTrain }, (_, i) => i)];
+    for (const valIdx of foldSets) {
+      const trainIdx = new Set(Array.from({ length: nTrain }, (_, i) => i).filter((i) => !valIdx.includes(i)));
+      const btTr = [];
+      const btVa = [];
+      const iva = [];
+      for (let i = 0; i < nTrain; i++) {
+        if (trainIdx.has(i)) btTr.push(btTrainRows[i]);
+        else {
+          btVa.push(btTrainRows[i]);
+          iva.push(i);
+        }
+      }
+      const model = trainBTModel(btTr);
+      const preds = predictBTDeterministic(model, btVa);
+      for (let j = 0; j < iva.length; j++) btOOF[iva[j]] = preds[j]?.prob ?? 0.5;
+    }
+  }
+
+  const weightsGrid = enumerateWeights(options.weightStep ?? 0.05);
+  const metrics = [];
+  for (const w of weightsGrid) {
+    const blend = labels.map((_, i) =>
+      w.logistic * (oofLogit[i] ?? 0.5) +
+      w.tree * (oofTree[i] ?? 0.5) +
+      w.bt * (btOOF[i] ?? 0.5) +
+      w.ann * (annOOF[i] ?? 0.5)
+    );
+    metrics.push({ weights: w, loss: logloss(blend, labels) ?? Infinity });
+  }
+  metrics.sort((a, b) => a.loss - b.loss);
+  const bestWeights = metrics[0]?.weights ?? defaultWeights();
+  const clampedWeights = clampWeights(bestWeights, weeksSeen || 1);
+  const oofBlend = labels.map((_, i) =>
+    clampedWeights.logistic * (oofLogit[i] ?? 0.5) +
+    clampedWeights.tree * (oofTree[i] ?? 0.5) +
+    clampedWeights.bt * (btOOF[i] ?? 0.5) +
+    clampedWeights.ann * (annOOF[i] ?? 0.5)
+  );
+  const calibrator = plattCalibrate(oofBlend, labels);
+  const oofBlendCal = oofBlend.map((p) => applyPlatt(p, calibrator));
+
+  const logitModelFull = trainLogisticGD(trainStd, labels, { steps: 3500, lr: 4e-3, l2: 2e-4 });
+  const treeParams = chooseTreeParams(trainStd.length);
+  const cartFull = new CART({ maxDepth: treeParams.depth, minNumSamples: treeParams.minSamples, gainFunction: "gini" });
+  if (trainStd.length) cartFull.train(trainStd, labels);
+  const leafStatsFull = buildLeafFreq(cartFull, trainStd, labels, laplaceAlpha(trainStd.length));
+  const annModelFull = trainANNCommittee(trainStd, labels, {
+    seeds: annSeeds,
+    maxEpochs: annMaxEpochs,
+    lr: 1e-3,
+    patience: 10,
+    timeLimitMs: options.annTimeLimit ?? 60000
+  });
+  const btModelFull = trainBTModel(btTrainRows);
+
+  const testMatrix = matrixFromRows(testRows, FEATS);
+  const testStd = applyScaler(testMatrix, scaler);
+  const logitTest = predictLogit(testStd, logitModelFull);
+  const treeTest = predictTree(cartFull, leafStatsFull, testStd);
+  const annTest = predictANNCommittee(annModelFull, testStd);
+  const btBootstrap = options.btBootstrapSamples ?? Number(process.env.BT_B ?? 1000);
+  const btPreds = predictBT({
+    model: btModelFull,
+    rows: btTestRows,
+    historyRows: btTrainRows,
+    bootstrap: btBootstrap,
+    block: options.btBlockSize ?? 5,
+    seed: options.btSeed ?? 17
+  });
+  const btMapPred = new Map(btPreds.map((p) => [p.game_id, p]));
+
+  const predictions = [];
+  for (let i = 0; i < testRows.length; i++) {
+    const row = testRows[i];
+    const btRow = btTestRows[i];
+    const btInfo = btMapPred.get(btRow.game_id) || { prob: 0.5, ci90: [0.25, 0.75], features: btRow.features };
+    const probs = {
+      logistic: logitTest[i] ?? 0.5,
+      tree: treeTest[i] ?? 0.5,
+      bt: btInfo.prob ?? 0.5,
+      ann: annTest[i] ?? 0.5
+    };
+    const preBlend =
+      clampedWeights.logistic * probs.logistic +
+      clampedWeights.tree * probs.tree +
+      clampedWeights.bt * probs.bt +
+      clampedWeights.ann * probs.ann;
+    const blended = applyPlatt(preBlend, calibrator);
+    probs.blended = blended;
+
+    const contribLogit = logitModelFull.w.map((w, idx) => ({
+      feature: FEATS[idx],
+      value: (w || 0) * (testStd[i]?.[idx] ?? 0)
+    }));
+    const path = leafPath(leafStatsFull.root, testStd[i] || []);
+    const leafRec = leafStatsFull.freq.get(path);
+    const leafWin = leafRec
+      ? (leafRec.n1 + leafStatsFull.alpha) / (leafRec.n0 + leafRec.n1 + 2 * leafStatsFull.alpha)
+      : 0.5;
+    const btStd = applyScaler([
+      BT_FEATURES.map((k) => Number(btInfo.features?.[k] ?? 0))
+    ], btModelFull.scaler)[0] || [];
+    const contribBT = btModelFull.w.map((w, idx) => ({ feature: BT_FEATURES[idx], value: (w || 0) * (btStd[idx] ?? 0) }));
+    const gradAnn = gradientANNCommittee(annModelFull, testStd[i] || []);
+    const contribAnn = gradAnn.map((g, idx) => ({ feature: FEATS[idx], value: g }));
+    const drivers = buildTopDrivers({
+      logisticContribs: contribLogit,
+      treeInfo: { path, winrate: leafWin },
+      btContribs: contribBT,
+      annGrad: contribAnn
     });
-    seasonSummary.built_through_week = W;
-    seasonIndex.weeks.push({
-      week: W,
-      predictions_file: `predictions_${SEASON}_W${String(W).padStart(2,"0")}.json`,
-      model_file:       `model_${SEASON}_W${String(W).padStart(2,"0")}.json`
+
+    predictions.push({
+      game_id: btRow.game_id,
+      home_team: row.team,
+      away_team: row.opponent,
+      season: row.season,
+      week: row.week,
+      forecast: round3(blended),
+      probs: {
+        logistic: round3(probs.logistic),
+        tree: round3(probs.tree),
+        bt: round3(probs.bt),
+        ann: round3(probs.ann),
+        blended: round3(blended)
+      },
+      blend_weights: {
+        logistic: round3(clampedWeights.logistic),
+        tree: round3(clampedWeights.tree),
+        bt: round3(clampedWeights.bt),
+        ann: round3(clampedWeights.ann)
+      },
+      calibration: {
+        pre: round3(preBlend),
+        post: round3(blended)
+      },
+      ci: {
+        bt90: btInfo.ci90?.map((v) => round3(v)) ?? [0.25, 0.75]
+      },
+      natural_language: buildNarrative({ home_team: row.team, away_team: row.opponent }, probs, btRow.features),
+      top_drivers: drivers,
+      actual: btRow.label_win
     });
-    latestWeekWritten = W;
   }
 
-  writeFileSync(`${ART_DIR}/season_index_${SEASON}.json`, JSON.stringify(seasonIndex, null, 2));
-  writeFileSync(`${ART_DIR}/season_summary_${SEASON}_to_W${String(seasonSummary.built_through_week || 0).padStart(2,"0")}.json`, JSON.stringify(seasonSummary, null, 2));
-  console.log(`WROTE: season_index_${SEASON}.json and season_summary_*`);
+  const metricsSummary = {
+    logistic: {
+      logloss: logloss(oofLogit, labels),
+      brier: brier(oofLogit, labels),
+      auc: auc(oofLogit, labels)
+    },
+    tree: {
+      logloss: logloss(oofTree, labels),
+      brier: brier(oofTree, labels),
+      auc: auc(oofTree, labels)
+    },
+    bt: {
+      logloss: logloss(btOOF, labels),
+      brier: brier(btOOF, labels),
+      auc: auc(btOOF, labels)
+    },
+    ann: {
+      logloss: logloss(annOOF, labels),
+      brier: brier(annOOF, labels),
+      auc: auc(annOOF, labels)
+    },
+    ensemble: {
+      logloss: logloss(oofBlendCal, labels),
+      brier: brier(oofBlendCal, labels),
+      auc: auc(oofBlendCal, labels)
+    }
+  };
 
-  if (latestWeekWritten != null) {
-    const fs = await import("fs/promises");
-    const predSrc  = `${ART_DIR}/predictions_${SEASON}_W${String(latestWeekWritten).padStart(2,"0")}.json`;
-    const modelSrc = `${ART_DIR}/model_${SEASON}_W${String(latestWeekWritten).padStart(2,"0")}.json`;
-    writeFileSync(`${ART_DIR}/predictions_current.json`, await fs.readFile(predSrc,  "utf8"));
-    writeFileSync(`${ART_DIR}/model_current.json`,      await fs.readFile(modelSrc, "utf8"));
-    console.log(`WROTE: artifacts/*_current.json aliases`);
-  }
-})().catch(e=>{ console.error(e); process.exit(1); });
+  const diagnostics = {
+    season: resolvedSeason,
+    week: resolvedWeek,
+    metrics: metricsSummary,
+    blend_weights: clampedWeights,
+    calibration_beta: calibrator.beta ?? 0,
+    calibration_bins: calibrationBins(oofBlendCal, labels),
+    n_train_rows: nTrain,
+    weeks_seen: weeksSeen,
+    training_weeks: [...new Set(trainRows.map((r) => r.week))].sort((a, b) => a - b)
+  };
+
+  const pca = computePCA(trainStd, FEATS);
+
+  const modelSummary = {
+    season: resolvedSeason,
+    week: resolvedWeek,
+    generated_at: new Date().toISOString(),
+    logistic: {
+      weights: logitModelFull.w,
+      bias: logitModelFull.b,
+      scaler,
+      features: FEATS
+    },
+    decision_tree: {
+      params: treeParams,
+      alpha: leafStatsFull.alpha
+    },
+    bt: {
+      coefficients: btModelFull.w,
+      intercept: btModelFull.b,
+      scaler: btModelFull.scaler,
+      features: BT_FEATURES
+    },
+    ann: {
+      seeds: annModelFull.seeds,
+      architecture: annModelFull.architecture,
+      committee_size: annModelFull.models.length
+    },
+    ensemble: {
+      weights: clampedWeights,
+      calibration_beta: calibrator.beta ?? 0
+    },
+    pca
+  };
+
+  const btDebug = btTestRows.map((row) => ({
+    game_id: row.game_id,
+    season: row.season,
+    week: row.week,
+    home_team: row.home_team,
+    away_team: row.away_team,
+    features: row.features,
+    home_context: row.home_context,
+    away_context: row.away_context
+  }));
+
+  return {
+    season: resolvedSeason,
+    week: resolvedWeek,
+    predictions,
+    modelSummary,
+    diagnostics,
+    btDebug
+  };
+}
+
+function writeArtifacts(result) {
+  const stamp = `${result.season}_W${String(result.week).padStart(2, "0")}`;
+  writeFileSync(`${ART_DIR}/predictions_${stamp}.json`, JSON.stringify(result.predictions, null, 2));
+  writeFileSync(`${ART_DIR}/model_${stamp}.json`, JSON.stringify(result.modelSummary, null, 2));
+  writeFileSync(`${ART_DIR}/diagnostics_${stamp}.json`, JSON.stringify(result.diagnostics, null, 2));
+  writeFileSync(`${ART_DIR}/bt_features_${stamp}.json`, JSON.stringify(result.btDebug, null, 2));
+}
+
+async function main() {
+  const season = Number(process.env.SEASON ?? new Date().getFullYear());
+  const weekEnv = Number(process.env.WEEK ?? 6);
+  const result = await runTraining({ season, week: weekEnv });
+  writeArtifacts(result);
+  console.log(`Trained ensemble for season ${result.season} week ${result.week}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,0 +1,161 @@
+// worker/worker.js
+// Cloudflare Worker serving predictions, models, diagnostics, and history endpoints.
+
+const REPO_USER = "impreet01";
+const REPO_NAME = "PerdictionNFL";
+const BRANCH = "main";
+
+const RAW_BASE = `https://raw.githubusercontent.com/${REPO_USER}/${REPO_NAME}/${BRANCH}/artifacts`;
+const GH_API_LIST = `https://api.github.com/repos/${REPO_USER}/${REPO_NAME}/contents/artifacts?ref=${BRANCH}`;
+
+const json = (obj, status = 200) =>
+  new Response(JSON.stringify(obj), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": status === 200 ? "public, max-age=900" : "no-store"
+    }
+  });
+
+async function listArtifacts() {
+  const resp = await fetch(GH_API_LIST, { headers: { "User-Agent": "cf-worker" } });
+  if (!resp.ok) throw new Error(`GitHub API list failed: ${resp.status}`);
+  return resp.json();
+}
+
+function parseFiles(listing, prefix) {
+  const out = [];
+  const regex = new RegExp(`^${prefix}_(\\d{4})_W(\\d{2})\\.json$`, "i");
+  for (const item of listing || []) {
+    if (!item || item.type !== "file") continue;
+    const m = regex.exec(item.name);
+    if (!m) continue;
+    out.push({ season: Number(m[1]), week: Number(m[2]), name: item.name });
+  }
+  out.sort((a, b) => (b.season - a.season) || (b.week - a.week));
+  return out;
+}
+
+async function resolveSeasonWeek(prefix, seasonParam, weekParam) {
+  let season = seasonParam ? Number(seasonParam) : null;
+  let week = weekParam ? Number(weekParam) : null;
+  if (Number.isFinite(season) && Number.isFinite(week)) return { season, week };
+  const listing = await listArtifacts();
+  const parsed = parseFiles(listing, prefix);
+  if (!parsed.length) throw new Error(`no ${prefix} artifacts found`);
+  if (!Number.isFinite(season)) {
+    season = parsed[0].season;
+  }
+  const forSeason = parsed.filter((r) => r.season === season);
+  if (!forSeason.length) throw new Error(`no ${prefix} artifacts for season ${season}`);
+  if (!Number.isFinite(week)) {
+    week = forSeason[0].week;
+  }
+  return { season, week };
+}
+
+async function fetchArtifact(prefix, season, week) {
+  const file = `${prefix}_${season}_W${String(week).padStart(2, "0")}.json`;
+  const url = `${RAW_BASE}/${file}`;
+  const resp = await fetch(url, { cf: { cacheEverything: true, cacheTtl: 900 } });
+  if (!resp.ok) throw new Error(`artifact not found for ${season} W${week}`);
+  return resp.json();
+}
+
+function filterHistory(predictions, predicate) {
+  const hits = [];
+  for (const entry of predictions) {
+    const arr = Array.isArray(entry.data) ? entry.data : [];
+    for (const game of arr) {
+      if (predicate(game)) {
+        hits.push({
+          season: entry.season,
+          week: entry.week,
+          game
+        });
+      }
+    }
+  }
+  hits.sort((a, b) => (a.season - b.season) || (a.week - b.week));
+  return hits;
+}
+
+async function historyResponse(query, mode) {
+  const team = query.get("team");
+  const home = query.get("home");
+  const away = query.get("away");
+  const seasonParam = query.get("season");
+  const listing = await listArtifacts();
+  const parsed = parseFiles(listing, "predictions");
+  const seasons = seasonParam ? [Number(seasonParam)] : [...new Set(parsed.map((p) => p.season))];
+  const payload = [];
+  for (const season of seasons) {
+    const weeks = parsed.filter((p) => p.season === season);
+    for (const wk of weeks) {
+      const data = await fetchArtifact("predictions", wk.season, wk.week).catch(() => []);
+      payload.push({ season: wk.season, week: wk.week, data });
+    }
+  }
+  let filtered;
+  if (mode === "team") {
+    if (!team) throw new Error("team query parameter required");
+    const teamUpper = team.toUpperCase();
+    filtered = filterHistory(payload, (game) =>
+      game.home_team?.toUpperCase() === teamUpper || game.away_team?.toUpperCase() === teamUpper
+    );
+  } else {
+    if (!home || !away) throw new Error("home and away query parameters required");
+    const homeUpper = home.toUpperCase();
+    const awayUpper = away.toUpperCase();
+    filtered = filterHistory(payload, (game) =>
+      game.home_team?.toUpperCase() === homeUpper && game.away_team?.toUpperCase() === awayUpper
+    );
+  }
+  return filtered.map((entry) => ({
+    season: entry.season,
+    week: entry.week,
+    home_team: entry.game.home_team,
+    away_team: entry.game.away_team,
+    probs: entry.game.probs,
+    blend_weights: entry.game.blend_weights,
+    calibration: entry.game.calibration,
+    top_drivers: entry.game.top_drivers,
+    natural_language: entry.game.natural_language,
+    actual: entry.game.actual
+  }));
+}
+
+export default {
+  async fetch(req) {
+    try {
+      const url = new URL(req.url);
+      const path = url.pathname;
+      if (path === "/predictions") {
+        const { season, week } = await resolveSeasonWeek("predictions", url.searchParams.get("season"), url.searchParams.get("week"));
+        const data = await fetchArtifact("predictions", season, week);
+        return json({ season, week, data });
+      }
+      if (path === "/models") {
+        const { season, week } = await resolveSeasonWeek("model", url.searchParams.get("season"), url.searchParams.get("week"));
+        const data = await fetchArtifact("model", season, week);
+        return json({ season, week, data });
+      }
+      if (path === "/diagnostics") {
+        const { season, week } = await resolveSeasonWeek("diagnostics", url.searchParams.get("season"), url.searchParams.get("week"));
+        const data = await fetchArtifact("diagnostics", season, week);
+        return json({ season, week, data });
+      }
+      if (path === "/history/team") {
+        const data = await historyResponse(url.searchParams, "team");
+        return json({ data });
+      }
+      if (path === "/history/game") {
+        const data = await historyResponse(url.searchParams, "matchup");
+        return json({ data });
+      }
+      return json({ error: "Unknown endpoint" }, 404);
+    } catch (err) {
+      return json({ error: String(err?.message || err) }, 500);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add a Bradley–Terry feature builder and bootstrap-powered logistic model to supply differential matchup inputs and confidence intervals
- overhaul `train_multi` to blend logistic, CART, BT, and ANN committees with PCA diagnostics, calibrated probabilities, top-driver explanations, and richer artifacts
- introduce a lightweight ANN committee trainer, expanded Cloudflare Worker endpoints, and regression/smoke tests to backstop the new ensemble

## Testing
- `node trainer/tests/smoke.js`
- `npm run train:multi` *(fails: ERR_FR_TOO_MANY_REDIRECTS when downloading nflverse schedules in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dafecd26308330b73d3f377f2670b2