### PR TITLE
Add offline-friendly schedule loading with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ Train and serve **logistic**, **decision-tree**, and **hybrid** NFL win probabil
 ## Notes
 - After first run, open an `artifacts/predictions_YYYY_WWW.json` to verify outputs.
 - If a column name mismatch occurs (nflverse schema drift), adjust the `map` object in `trainer/featureBuild.js`.
+
+## Offline-friendly schedules
+- `trainer/dataSources.loadSchedules` now checks multiple sources in order: a local override (`NFLVERSE_SCHEDULES_FILE` or `./data/games.csv`), a cached copy (`NFLVERSE_SCHEDULES_CACHE` or `artifacts/cache/games.csv`), the main GitHub raw file, and finally a CDN mirror.
+- Successful remote downloads are saved to the cache path so that subsequent runs can stay offline.
+- `npm run train:multi` and helper scripts accept `--cache=/path/to/games.csv` (and `--local=...`) to exercise the offline branch. For example:
+  ```bash
+  NO_PROXY=localhost npm run train:multi -- --cache=artifacts/cache/games.csv
+  node trainer/tests/smoke.js
+  ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,396 @@
+{
+  "name": "nfl-wins-free-stack",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nfl-wins-free-stack",
+      "version": "1.0.0",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "ml-cart": "^2.0.1",
+        "ml-logistic-regression": "^2.0.0",
+        "ml-matrix": "^6.11.0",
+        "papaparse": "^5.4.1",
+        "undici": "^7.16.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ml-array-max": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
+      "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-mean": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
+      "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-sum": "^1.1.6"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
+      "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
+      "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0",
+        "ml-array-max": "^1.2.4",
+        "ml-array-min": "^1.2.3"
+      }
+    },
+    "node_modules/ml-array-sum": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
+      "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-cart": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ml-cart/-/ml-cart-2.1.1.tgz",
+      "integrity": "sha512-f6rIj4EzbjqKLJa2Qmm5AjZ0WVgk+Y7J1N/+pQVaFr0d4oM1uZPLOh5h665LyH+bLBHTFEbvSR4OLKmJRQ8KfA==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-mean": "^1.1.5",
+        "ml-matrix": "^6.8.2"
+      }
+    },
+    "node_modules/ml-logistic-regression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-logistic-regression/-/ml-logistic-regression-2.0.0.tgz",
+      "integrity": "sha512-xHhB91ut8GRRbJyB1ZQfKsl1MHmE1PqMeRjxhks96M5BGvCbC9eEojf4KgRMKM2LxFblhVUcVzweAoPB48Nt0A==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-matrix": "^6.5.0"
+      }
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.1.tgz",
+      "integrity": "sha512-TJ+8eOFdp+INvzR4zAuwBQJznDUfktMtOB6g/hUcGh3rcyjxbz4Te57Pgri8Q9bhSQ7Zys4IYOGhFdnlgeB6Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.1",
+        "ml-array-rescale": "^1.3.7"
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ml-cart": "^2.0.1",
     "ml-logistic-regression": "^2.0.0",
     "ml-matrix": "^6.11.0",
-    "papaparse": "^5.4.1"
+    "papaparse": "^5.4.1",
+    "undici": "^7.16.0"
   }
 }

--- a/scripts/resolveWeek.js
+++ b/scripts/resolveWeek.js
@@ -4,6 +4,12 @@
 
 import { loadSchedules } from "../trainer/dataSources.js";
 
+function readOpt(name) {
+  const prefix = `${name}=`;
+  const entry = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
+  return entry ? entry.slice(prefix.length) : undefined;
+}
+
 function isReg(v) {
   if (v == null) return true;
   const s = String(v).trim().toUpperCase();
@@ -18,7 +24,10 @@ function hasFinalScore(g) {
 
 async function main() {
   const SEASON = Number(process.env.SEASON || new Date().getFullYear());
-  const schedules = await loadSchedules();
+  const schedules = await loadSchedules({
+    localPath: readOpt("--local"),
+    cachePath: readOpt("--cache") || process.env.NFLVERSE_SCHEDULES_CACHE,
+  });
 
   const reg = schedules.filter(
     (g) => Number(g.season) === SEASON && isReg(g.season_type)

--- a/trainer/dataSources.js
+++ b/trainer/dataSources.js
@@ -2,22 +2,68 @@
 // Downloads nflverse schedules and team weekly stats (CSV or CSV.GZ) for a given season.
 // Uses the asset pattern: stats_team_week_<season>.csv[.gz]
 
-import axios from "axios";
 import Papa from "papaparse";
 import { gunzipSync } from "node:zlib"; // <-- use Node built-in zlib
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { URL } from "node:url";
+import { fetch as undiciFetch, ProxyAgent } from "undici";
 
 const NFLVERSE_RELEASE = "https://github.com/nflverse/nflverse-data/releases/download";
 const STATS_TEAM_TAG = "stats_team";
 const SCHEDULES_URL = "https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv";
+const SCHEDULES_MIRROR = "https://cdn.jsdelivr.net/gh/nflverse/nfldata@master/data/games.csv";
+const DEFAULT_LOCAL_SCHEDULES = "./data/games.csv";
+const DEFAULT_CACHE_SCHEDULES = "artifacts/cache/games.csv";
+const PROXY_URL = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || null;
+const dispatcher = PROXY_URL ? new ProxyAgent(PROXY_URL) : undefined;
+const NO_PROXY_RAW = process.env.NO_PROXY || process.env.no_proxy || "";
+const NO_PROXY_LIST = NO_PROXY_RAW.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+
+function shouldBypassProxy(url) {
+  if (!dispatcher || !NO_PROXY_LIST.length) return false;
+  let host = "";
+  let port = "";
+  try {
+    const parsed = new URL(url);
+    host = (parsed.hostname || "").toLowerCase();
+    port = parsed.port || "";
+  } catch {
+    return false;
+  }
+  const hostPort = port ? `${host}:${port}` : host;
+  return NO_PROXY_LIST.some((entryRaw) => {
+    const entry = entryRaw.trim();
+    if (!entry) return false;
+    if (entry === "*") return true;
+    if (entry === hostPort) return true;
+    if (!port && entry === host) return true;
+    if (!entry.includes(":")) {
+      const domain = entry.startsWith(".") ? entry.slice(1) : entry;
+      if (host === domain) return true;
+      if (host.endsWith(`.${domain}`)) return true;
+    }
+    return false;
+  });
+}
 
 function parseCSV(text) {
   const parsed = Papa.parse(text, { header: true, dynamicTyping: true, skipEmptyLines: true });
   return parsed.data;
 }
 
+async function fetchWithProxy(url, options = {}) {
+  const useDispatcher = dispatcher && !shouldBypassProxy(url) ? dispatcher : undefined;
+  const res = await undiciFetch(url, useDispatcher ? { ...options, dispatcher: useDispatcher } : options);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} for ${url}`);
+  }
+  return res;
+}
+
 async function fetchText(url) {
-  const { data } = await axios.get(url, { responseType: "text" });
-  return data;
+  const res = await fetchWithProxy(url);
+  return res.text();
 }
 
 async function fetchCSVMaybeGz(url) {
@@ -26,9 +72,10 @@ async function fetchCSVMaybeGz(url) {
     return parseCSV(text);
   }
   if (url.endsWith(".csv.gz")) {
-    const { data, headers } = await axios.get(url, { responseType: "arraybuffer" });
-    let buf = Buffer.from(data);
-    const enc = (headers["content-encoding"] || "").toLowerCase();
+    const res = await fetchWithProxy(url);
+    const arrayBuf = await res.arrayBuffer();
+    let buf = Buffer.from(arrayBuf);
+    const enc = (res.headers.get("content-encoding") || "").toLowerCase();
     if (enc.includes("gzip")) {
       buf = gunzipSync(buf);
     } else {
@@ -40,9 +87,59 @@ async function fetchCSVMaybeGz(url) {
   throw new Error(`Unsupported extension for ${url}`);
 }
 
-export async function loadSchedules() {
-  const text = await fetchText(SCHEDULES_URL);
+function persistCache(cachePath, text) {
+  if (!cachePath) return;
+  try {
+    mkdirSync(dirname(cachePath), { recursive: true });
+    writeFileSync(cachePath, text, "utf8");
+  } catch {
+    // best effort; ignore cache write failures
+  }
+}
+
+function parseLocalFile(path) {
+  const text = readFileSync(path, "utf8");
   return parseCSV(text);
+}
+
+export async function loadSchedules({ localPath, cachePath } = {}) {
+  const resolvedLocal = localPath ?? process.env.NFLVERSE_SCHEDULES_FILE ?? DEFAULT_LOCAL_SCHEDULES;
+  const resolvedCache = cachePath ?? process.env.NFLVERSE_SCHEDULES_CACHE ?? DEFAULT_CACHE_SCHEDULES;
+  const attempts = [];
+
+  const tryLocal = (path, label) => {
+    if (!path) return null;
+    try {
+      return parseLocalFile(path);
+    } catch (err) {
+      attempts.push(`${label} (${path}): ${err?.message || err}`);
+      return null;
+    }
+  };
+
+  const localRows = tryLocal(resolvedLocal, "local schedules file");
+  if (localRows) return localRows;
+
+  if (!resolvedCache || resolvedCache === resolvedLocal) {
+    // avoid double-attempt if cache path equals local path and already failed
+  } else {
+    const cacheRows = tryLocal(resolvedCache, "cached schedules file");
+    if (cacheRows) return cacheRows;
+  }
+
+  const remoteSources = [SCHEDULES_URL, SCHEDULES_MIRROR];
+  for (const url of remoteSources) {
+    try {
+      const text = await fetchText(url);
+      persistCache(resolvedCache, text);
+      return parseCSV(text);
+    } catch (err) {
+      attempts.push(`remote ${url}: ${err?.message || err}`);
+    }
+  }
+
+  const detail = attempts.length ? ` Attempts: ${attempts.join(" | ")}` : "";
+  throw new Error(`Could not load schedules from any source.${detail}`);
 }
 
 export async function loadTeamWeekly(season) {

--- a/trainer/tests/smoke.js
+++ b/trainer/tests/smoke.js
@@ -1,0 +1,30 @@
+import { strict as assert } from "node:assert";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSchedules } from "../dataSources.js";
+
+async function main() {
+  const tmp = mkdtempSync(join(tmpdir(), "nfl-sched-cache-"));
+  const cacheFile = join(tmp, "games.csv");
+  const csv = [
+    "season,week,home_team,away_team,home_score,away_score,season_type",
+    "2023,1,KC,DET,20,21,REG"
+  ].join("\n");
+  writeFileSync(cacheFile, csv, "utf8");
+
+  const rows = await loadSchedules({
+    localPath: join(tmp, "missing.csv"),
+    cachePath: cacheFile,
+  });
+
+  assert.equal(rows.length, 1, "should read cached schedule row");
+  assert.equal(rows[0].home_team, "KC");
+  assert.equal(rows[0].away_team, "DET");
+  console.log("smoke: loadSchedules cache fallback ok");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/trainer/train_multi.js
+++ b/trainer/train_multi.js
@@ -14,6 +14,11 @@ mkdirSync(ART_DIR, { recursive: true });
 
 const SEASON = Number(process.env.SEASON || new Date().getFullYear());
 const WEEK_ENV = Number(process.env.WEEK || 6);
+const readOpt = (name) => {
+  const prefix = `${name}=`;
+  const arg = process.argv.slice(2).find((v) => v.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+};
 
 function isReg(v){ if (v == null) return true; const s=String(v).trim().toUpperCase(); return s==="" || s.startsWith("REG"); }
 const sigmoid = z => 1/(1+Math.exp(-z));
@@ -242,7 +247,10 @@ function dedupeToHomeView(items) {
 (async function main(){
   console.log(`Rolling train for SEASON=${SEASON} (env WEEK=${WEEK_ENV})`);
 
-  const schedules = await loadSchedules();
+  const schedules = await loadSchedules({
+    localPath: readOpt("--local") ?? process.env.NFLVERSE_SCHEDULES_FILE,
+    cachePath: readOpt("--cache") ?? process.env.NFLVERSE_SCHEDULES_CACHE,
+  });
   const teamWeekly = await loadTeamWeekly(SEASON);
   const prevTeamWeekly = await (async()=>{ try { return await loadTeamWeekly(SEASON-1); } catch { return []; } })();
 


### PR DESCRIPTION
## Summary
- add proxy-aware multi-source loading with caching for schedules and persist remote fetches locally
- expose cache/local CLI overrides to resolveWeek and train_multi, plus add a smoke test and documentation
- include undici dependency for proxy support and update README with offline usage instructions

## Testing
- npm run train:multi
- NO_PROXY=localhost,127.0.0.1,::1,raw.githubusercontent.com npm run train:multi -- --cache=artifacts/cache/games.csv
- node trainer/tests/smoke.js

------
https://chatgpt.com/codex/tasks/task_e_68db0b731edc83309dae716b64d9529c