### PR TITLE
Integrate advanced team-game features and enhance BT narrative

### DIFF
--- a/scripts/debugData.js
+++ b/scripts/debugData.js
@@ -1,5 +1,5 @@
 // scripts/debugData.js
-import { loadSchedules, loadTeamWeekly } from "../trainer/dataSources.js";
+import { loadSchedules, loadTeamWeekly, loadTeamGameAdvanced } from "../trainer/dataSources.js";
 import { buildFeatures } from "../trainer/featureBuild.js";
 
 const SEASON = Number(process.env.SEASON || new Date().getFullYear());
@@ -32,6 +32,14 @@ function counts(arr, key) {
     console.log(`loadTeamWeekly(${SEASON}) failed: ${e?.message || e}`);
   }
 
+  let teamGame = [];
+  try {
+    teamGame = await loadTeamGameAdvanced(SEASON);
+    console.log(`teamGame rows (season ${SEASON}): ${teamGame.length}`);
+  } catch (e) {
+    console.log(`loadTeamGameAdvanced(${SEASON}) failed: ${e?.message || e}`);
+  }
+
   let prevTeamWeekly = [];
   try {
     prevTeamWeekly = await loadTeamWeekly(SEASON - 1);
@@ -40,7 +48,7 @@ function counts(arr, key) {
     console.log(`loadTeamWeekly(${SEASON - 1}) failed: ${e?.message || e}`);
   }
 
-  const featRows = buildFeatures({ teamWeekly, schedules, season: SEASON, prevTeamWeekly });
+  const featRows = buildFeatures({ teamWeekly, teamGame, schedules, season: SEASON, prevTeamWeekly });
   console.log(`feature rows (REG relaxed): ${featRows.length}`);
   const train = featRows.filter(r => r.season === SEASON && r.week < WEEK);
   const test  = featRows.filter(r => r.season === SEASON && r.week === WEEK);

--- a/trainer/featureBuild.js
+++ b/trainer/featureBuild.js
@@ -1,279 +1,472 @@
 // trainer/featureBuild.js
 //
-// Build season-to-date (S2D) features from NFLVerse team-week PER-GAME stats.
-// Derive defensive "allowed" values from the opponent row for the same game/week.
-// Always emit rows for weeks that exist in the data; DO NOT fabricate future weeks.
-// Win label only when final scores exist in schedule; otherwise win=null.
+// Build season-to-date (S2D) features from nflverse team-week and team-game datasets.
+// Includes baseline cumulative stats plus advanced situational rates derived from team_game.
+// Defensive "allowed" values are taken from the opponent row in the same game/week.
+// Only generates rows for actual games (no fabrication of future weeks).
 
-const FEATS = [
-  "off_1st_down_s2d","off_total_yds_s2d","off_rush_yds_s2d","off_pass_yds_s2d","off_turnovers_s2d",
-  "def_1st_down_s2d","def_total_yds_s2d","def_rush_yds_s2d","def_pass_yds_s2d","def_turnovers_s2d",
-  "wins_s2d","losses_s2d","home",
-  "sim_winrate_same_loc_s2d","sim_pointdiff_same_loc_s2d","sim_count_same_loc_s2d",
-  "off_total_yds_s2d_minus_opp","def_total_yds_s2d_minus_opp",
-  "off_turnovers_s2d_minus_opp","def_turnovers_s2d_minus_opp",
-  "elo_pre","elo_diff","rest_days","rest_diff"
+export const FEATS = [
+  "off_1st_down_s2d",
+  "off_total_yds_s2d",
+  "off_rush_yds_s2d",
+  "off_pass_yds_s2d",
+  "off_turnovers_s2d",
+  "def_1st_down_s2d",
+  "def_total_yds_s2d",
+  "def_rush_yds_s2d",
+  "def_pass_yds_s2d",
+  "def_turnovers_s2d",
+  "wins_s2d",
+  "losses_s2d",
+  "home",
+  "sim_winrate_same_loc_s2d",
+  "sim_pointdiff_same_loc_s2d",
+  "sim_count_same_loc_s2d",
+  "off_total_yds_s2d_minus_opp",
+  "def_total_yds_s2d_minus_opp",
+  "off_turnovers_s2d_minus_opp",
+  "def_turnovers_s2d_minus_opp",
+  "elo_pre",
+  "elo_diff",
+  "rest_days",
+  "rest_diff",
+  "off_third_down_att_s2d",
+  "off_third_down_conv_s2d",
+  "off_third_down_pct_s2d",
+  "off_red_zone_att_s2d",
+  "off_red_zone_td_s2d",
+  "off_red_zone_td_pct_s2d",
+  "off_dropbacks_s2d",
+  "off_sacks_taken_s2d",
+  "off_sack_rate_s2d",
+  "off_pass_att_s2d",
+  "off_rush_att_s2d",
+  "off_neutral_pass_rate_s2d",
+  "off_third_down_pct_s2d_minus_opp",
+  "off_red_zone_td_pct_s2d_minus_opp",
+  "off_sack_rate_s2d_minus_opp",
+  "off_neutral_pass_rate_s2d_minus_opp"
 ];
 
-function isReg(v){ if (v == null) return true; const s=String(v).trim().toUpperCase(); return s==="" || s.startsWith("REG"); }
-const num = (v,d=0)=>{ const n=Number(v); return Number.isFinite(n)?n:d; };
-const dateOnly = s => s ? String(s).slice(0,10) : null;
+const isReg = (v) => {
+  if (v == null) return true;
+  const s = String(v).trim().toUpperCase();
+  return s === "" || s.startsWith("REG");
+};
 
-function finalScores(g){
-  const hs = g.home_score ?? g.home_points ?? g.home_pts;
-  const as = g.away_score ?? g.away_points ?? g.away_pts;
+const num = (value, def = 0) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : def;
+};
+
+const dateOnly = (value) => (value ? String(value).slice(0, 10) : null);
+
+const normTeam = (value) => {
+  if (!value) return null;
+  const s = String(value).trim().toUpperCase();
+  return s || null;
+};
+
+function finalScores(game) {
+  const hs = game.home_score ?? game.home_points ?? game.home_pts;
+  const as = game.away_score ?? game.away_points ?? game.away_pts;
   if (!Number.isFinite(Number(hs)) || !Number.isFinite(Number(as))) return null;
   return { hs: Number(hs), as: Number(as) };
 }
-function winLabel(g, isHome){
-  const fs = finalScores(g); if (!fs) return null;
-  if (fs.hs === fs.as) return null;
-  const homeWon = fs.hs > fs.as ? 1 : 0;
-  return isHome ? homeWon : (1 - homeWon);
+
+function winLabel(game, isHome) {
+  const scores = finalScores(game);
+  if (!scores) return null;
+  if (scores.hs === scores.as) return null;
+  const homeWon = scores.hs > scores.as ? 1 : 0;
+  return isHome ? homeWon : 1 - homeWon;
 }
 
-function daysBetween(a, b){
+const daysBetween = (a, b) => {
   if (!a || !b) return 0;
-  return Math.round((new Date(b) - new Date(a)) / 86400000);
-}
+  return Math.round((new Date(b) - new Date(a)) / 86_400_000);
+};
 
-// Build an index: season-week-team -> row
-function indexTeamWeek(rows, season){
+function indexTeamWeek(rows = [], season) {
   const idx = new Map();
-  for (const r of rows){
-    if (Number(r.season) !== season) continue;
-    const key = `${r.season}-${r.week}-${r.team}`;
-    idx.set(key, r);
+  for (const row of rows) {
+    if (Number(row.season) !== Number(season)) continue;
+    const team = normTeam(row.team ?? row.team_abbr ?? row.team_code);
+    if (!team) continue;
+    const week = Number(row.week ?? row.game_week ?? row.week_number);
+    if (!Number.isFinite(week)) continue;
+    idx.set(`${season}-${week}-${team}`, row);
   }
   return idx;
 }
 
-// Compute per-row offensive and defensive per-game metrics we need
-function perGameSignals(r, oppRow){
-  // Offense
-  const passYds = num(r.passing_yards);
-  const rushYds = num(r.rushing_yards);
+function indexTeamGame(rows = [], season) {
+  const idx = new Map();
+  for (const row of rows) {
+    if (Number(row.season) !== Number(season)) continue;
+    const team = normTeam(row.team ?? row.team_abbr ?? row.team_code ?? row.posteam);
+    if (!team) continue;
+    const week = Number(row.week ?? row.game_week ?? row.week_number);
+    if (!Number.isFinite(week)) continue;
+    idx.set(`${season}-${week}-${team}`, row);
+  }
+  return idx;
+}
+
+function perGameSignals(row = {}, oppRow = {}) {
+  const passYds = num(row.passing_yards ?? row.pass_yards ?? row.pass_yds);
+  const rushYds = num(row.rushing_yards ?? row.rush_yards ?? row.rush_yds);
   const offTotal = passYds + rushYds;
 
-  const passFD = num(r.passing_first_downs);
-  const rushFD = num(r.rushing_first_downs);
-  const recvFD = num(r.receiving_first_downs);
+  const passFD = num(row.passing_first_downs ?? row.pass_first_downs);
+  const rushFD = num(row.rushing_first_downs ?? row.rush_first_downs);
+  const recvFD = num(row.receiving_first_downs ?? row.rec_first_downs);
   const offFD = passFD + rushFD + recvFD;
 
-  const offINT = num(r.passing_interceptions);
-  const offFumLost = num(r.rushing_fumbles_lost) + num(r.receiving_fumbles_lost) + num(r.sack_fumbles_lost);
+  const offINT = num(row.passing_interceptions ?? row.interceptions ?? row.pass_int);
+  const offFumLost =
+    num(row.rushing_fumbles_lost ?? row.rush_fumbles_lost ?? row.fumbles_lost) +
+    num(row.receiving_fumbles_lost ?? row.rec_fumbles_lost) +
+    num(row.sack_fumbles_lost);
   const offTO = offINT + offFumLost;
 
-  // Defense (allowed) via opponent offense row
-  const oppPassYds = oppRow ? num(oppRow.passing_yards) : 0;
-  const oppRushYds = oppRow ? num(oppRow.rushing_yards) : 0;
+  const oppPassYds = num(oppRow.passing_yards ?? oppRow.pass_yards ?? oppRow.pass_yds);
+  const oppRushYds = num(oppRow.rushing_yards ?? oppRow.rush_yards ?? oppRow.rush_yds);
   const defTotalAllowed = oppPassYds + oppRushYds;
 
-  const oppPassFD = oppRow ? num(oppRow.passing_first_downs) : 0;
-  const oppRushFD = oppRow ? num(oppRow.rushing_first_downs) : 0;
-  const oppRecvFD = oppRow ? num(oppRow.receiving_first_downs) : 0;
+  const oppPassFD = num(oppRow.passing_first_downs ?? oppRow.pass_first_downs);
+  const oppRushFD = num(oppRow.rushing_first_downs ?? oppRow.rush_first_downs);
+  const oppRecvFD = num(oppRow.receiving_first_downs ?? oppRow.rec_first_downs);
   const defFDAllowed = oppPassFD + oppRushFD + oppRecvFD;
 
-  // Takeaways (made by defense)
-  const defINT = num(r.def_interceptions);
-  // "def_fumbles" = fumbles recovered; if not precise in your source, this is a decent proxy
-  const defFum = num(r.def_fumbles);
+  const defINT = num(row.def_interceptions ?? row.def_int);
+  const defFum = num(row.def_fumbles ?? row.def_fumbles_recovered ?? row.fumbles_forced);
   const defTO = defINT + defFum;
 
   return {
-    offFD, offTotal, rushYds, passYds, offTO,
-    defFDAllowed, defTotalAllowed, defRushAllowed: oppRushYds, defPassAllowed: oppPassYds, defTO
+    offFD,
+    offTotal,
+    rushYds,
+    passYds,
+    offTO,
+    defFDAllowed,
+    defTotalAllowed,
+    defRushAllowed: oppRushYds,
+    defPassAllowed: oppPassYds,
+    defTO
   };
 }
 
-// Tiny Elo seed: previous season wins (if prev season provided), otherwise 1500
-function seedElo(team, prevTeamWeekly){
-  const wins = (prevTeamWeekly||[]).filter(r => r.team===team).reduce((s,r)=> s + num(r.wins,0), 0);
-  return Number.isFinite(wins) ? 1450 + 5*wins : 1500;
+function pick(row, keys = []) {
+  for (const key of keys) {
+    if (row && row[key] != null && row[key] !== "") return row[key];
+  }
+  return 0;
 }
 
-// Similar-opponent aggregates (same venue) based on rows with labels so far
-function buildSimilarAgg(rowsSoFar){
-  const idx = new Map(); // key `${team}-${home}` -> rows
-  for (const r of rowsSoFar){
-    if (!(r.win===0 || r.win===1)) continue;
-    const key = `${r.team}-${r.home}`;
-    const arr = idx.get(key) || [];
-    arr.push(r); idx.set(key, arr);
-  }
-  function dist(a,b){
-    let d=0;
-    d += Math.abs(num(a.off_total_yds_s2d) - num(b.off_total_yds_s2d));
-    d += Math.abs(num(a.def_total_yds_s2d) - num(b.def_total_yds_s2d));
-    d += 50*Math.abs(num(a.off_turnovers_s2d) - num(b.off_turnovers_s2d));
-    d += 50*Math.abs(num(a.def_turnovers_s2d) - num(b.def_turnovers_s2d));
-    return d;
-  }
-  return function(team, home, candidate){
-    const pool = idx.get(`${team}-${home}`) || [];
-    if (!pool.length) return { winrate: 0, pointdiff: 0, count: 0 };
-    const dists = pool.map(e => dist(e, candidate)).sort((a,b)=>a-b);
-    const med = dists[Math.floor(dists.length/2)] || 0;
-    const band = Math.max(50, med*1.5);
-    let sel = pool.filter(e => dist(e, candidate) <= band);
-    if (!sel.length) sel = pool.slice(0, Math.min(5, pool.length));
-    const winrate = sel.reduce((s,e)=> s + (e.win?1:0), 0) / sel.length;
-    const pointdiff = sel.reduce((s,e)=> s + ((num(e.off_total_yds_s2d)-num(e.def_total_yds_s2d))), 0) / sel.length;
-    return { winrate, pointdiff, count: sel.length };
+function advancedSignals(row = {}) {
+  const thirdAtt = num(pick(row, [
+    "third_down_att",
+    "third_down_attempts",
+    "third_down_attempt",
+    "third_downs_att",
+    "third_downs"
+  ]));
+  const thirdConv = num(pick(row, [
+    "third_down_conv",
+    "third_down_conversions",
+    "third_down_success",
+    "third_downs_conv",
+    "third_downs_made"
+  ]));
+  const redAtt = num(pick(row, [
+    "red_zone_att",
+    "red_zone_attempts",
+    "red_zone_trips",
+    "redzone_att",
+    "rz_att"
+  ]));
+  const redTD = num(pick(row, [
+    "red_zone_td",
+    "red_zone_tds",
+    "red_zone_touchdowns",
+    "redzone_td",
+    "rz_td",
+    "rz_tds"
+  ]));
+  const passAtt = num(pick(row, [
+    "pass_att",
+    "pass_attempts",
+    "passing_attempts",
+    "attempts_pass",
+    "attempt_pass"
+  ]));
+  const rushAtt = num(pick(row, [
+    "rush_att",
+    "rush_attempts",
+    "rushing_attempts",
+    "attempts_rush",
+    "attempt_rush"
+  ]));
+  const sacksTaken = num(pick(row, [
+    "sacks_taken",
+    "qb_sacked",
+    "sacks",
+    "sacks_allowed",
+    "times_sacked"
+  ]));
+
+  return {
+    thirdAtt,
+    thirdConv,
+    redAtt,
+    redTD,
+    passAtt,
+    rushAtt,
+    sacksTaken
   };
 }
 
-export function buildFeatures({ teamWeekly, schedules, season, prevTeamWeekly }){
-  const out = [];
-  // Keep REG only, index by (season,week,team) for opponent lookup
-  const regSched = schedules.filter(g => Number(g.season)===season && isReg(g.season_type));
-  const tw = (teamWeekly||[]).filter(r => Number(r.season)===season);
-  if (!tw.length) return out;
+function updateAdvanced(prev = {}, metrics = {}) {
+  const thirdAtt = num(prev.off_third_down_att_s2d) + num(metrics.thirdAtt);
+  const thirdConv = num(prev.off_third_down_conv_s2d) + num(metrics.thirdConv);
+  const redAtt = num(prev.off_red_zone_att_s2d) + num(metrics.redAtt);
+  const redTD = num(prev.off_red_zone_td_s2d) + num(metrics.redTD);
+  const passAtt = num(prev.off_pass_att_s2d) + num(metrics.passAtt);
+  const rushAtt = num(prev.off_rush_att_s2d) + num(metrics.rushAtt);
+  const sacks = num(prev.off_sacks_taken_s2d) + num(metrics.sacksTaken);
+  const dropbacks = passAtt + sacks;
+  const neutralDenom = passAtt + rushAtt;
 
-  const twIdx = indexTeamWeek(tw, season);
-  const weeks = [...new Set(tw.map(r => Number(r.week)).filter(Number.isFinite))].sort((a,b)=>a-b);
-  const teams = new Set(regSched.flatMap(g => [g.home_team, g.away_team]).filter(Boolean));
+  return {
+    off_third_down_att_s2d: thirdAtt,
+    off_third_down_conv_s2d: thirdConv,
+    off_third_down_pct_s2d: thirdAtt ? thirdConv / thirdAtt : 0,
+    off_red_zone_att_s2d: redAtt,
+    off_red_zone_td_s2d: redTD,
+    off_red_zone_td_pct_s2d: redAtt ? redTD / redAtt : 0,
+    off_pass_att_s2d: passAtt,
+    off_rush_att_s2d: rushAtt,
+    off_sacks_taken_s2d: sacks,
+    off_dropbacks_s2d: dropbacks,
+    off_sack_rate_s2d: dropbacks ? sacks / dropbacks : 0,
+    off_neutral_pass_rate_s2d: neutralDenom ? passAtt / neutralDenom : 0
+  };
+}
+
+function zeroAdvanced() {
+  return {
+    off_third_down_att_s2d: 0,
+    off_third_down_conv_s2d: 0,
+    off_third_down_pct_s2d: 0,
+    off_red_zone_att_s2d: 0,
+    off_red_zone_td_s2d: 0,
+    off_red_zone_td_pct_s2d: 0,
+    off_pass_att_s2d: 0,
+    off_rush_att_s2d: 0,
+    off_sacks_taken_s2d: 0,
+    off_dropbacks_s2d: 0,
+    off_sack_rate_s2d: 0,
+    off_neutral_pass_rate_s2d: 0
+  };
+}
+
+function seedElo(team, prevTeamWeekly) {
+  const wins = (prevTeamWeekly || [])
+    .filter((row) => normTeam(row.team) === team)
+    .reduce((sum, row) => sum + num(row.wins ?? row.win ?? 0), 0);
+  return Number.isFinite(wins) ? 1450 + 5 * wins : 1500;
+}
+
+export function buildFeatures({ teamWeekly, teamGame = [], schedules, season, prevTeamWeekly }) {
+  const seasonNum = Number(season);
+  if (!Number.isFinite(seasonNum)) return [];
+
+  const regSched = (schedules || []).filter(
+    (game) => Number(game.season) === seasonNum && isReg(game.season_type)
+  );
+  if (!regSched.length) return [];
+
+  const weeks = [...new Set(regSched.map((g) => Number(g.week)).filter(Number.isFinite))].sort(
+    (a, b) => a - b
+  );
+
+  const teams = new Set(
+    regSched
+      .flatMap((g) => [normTeam(g.home_team), normTeam(g.away_team)])
+      .filter((t) => t)
+  );
+
+  const twIdx = indexTeamWeek(teamWeekly || [], seasonNum);
+  const tgIdx = indexTeamGame(teamGame || [], seasonNum);
+
   const lastDate = new Map();
-  const elo = new Map(); for (const t of teams) elo.set(t, seedElo(t, prevTeamWeekly));
+  const elo = new Map();
+  for (const team of teams) {
+    elo.set(team, seedElo(team, prevTeamWeekly));
+  }
 
-  // S2D accumulators: team -> rolled sums by week
-  const roll = new Map(); // team -> {week -> s2d object}
-  for (const team of teams) roll.set(team, new Map());
+  const roll = new Map();
+  const advRoll = new Map();
+  for (const team of teams) {
+    roll.set(team, new Map());
+    advRoll.set(team, new Map());
+  }
 
-  const rowsSoFar = [];
-  for (const W of weeks){
-    const games = regSched.filter(g => Number(g.week)===W);
+  const out = [];
+
+  for (const week of weeks) {
+    const games = regSched.filter((g) => Number(g.week) === week);
     if (!games.length) continue;
 
-    for (const g of games){
-      const H = g.home_team, A = g.away_team;
-      const gd = dateOnly(g.game_date);
+    for (const game of games) {
+      const home = normTeam(game.home_team);
+      const away = normTeam(game.away_team);
+      if (!home || !away) continue;
 
-      // source rows for this (season, week) for each team
-      const hRow = twIdx.get(`${season}-${W}-${H}`) || null;
-      const aRow = twIdx.get(`${season}-${W}-${A}`) || null;
+      const gameDate = dateOnly(game.game_date);
 
-      // opponent rows for defensive derivations
-      // (note: we want the opponent's offensive stats)
-      const hOpp = aRow;
-      const aOpp = hRow;
+      const hKey = `${seasonNum}-${week}-${home}`;
+      const aKey = `${seasonNum}-${week}-${away}`;
+      const hRow = twIdx.get(hKey) || {};
+      const aRow = twIdx.get(aKey) || {};
+      const hAdvRow = tgIdx.get(hKey) || {};
+      const aAdvRow = tgIdx.get(aKey) || {};
 
-      const hPG = perGameSignals(hRow||{}, hOpp||{});
-      const aPG = perGameSignals(aRow||{}, aOpp||{});
+      const hOppRow = aRow;
+      const aOppRow = hRow;
 
-      // roll S2D
-      function updateRoll(team, prev, pg){
-        const s = { ...prev };
-        s.off_1st_down_s2d = num(prev.off_1st_down_s2d) + num(pg.offFD);
-        s.off_total_yds_s2d = num(prev.off_total_yds_s2d) + num(pg.offTotal);
-        s.off_rush_yds_s2d = num(prev.off_rush_yds_s2d) + num(pg.rushYds);
-        s.off_pass_yds_s2d = num(prev.off_pass_yds_s2d) + num(pg.passYds);
-        s.off_turnovers_s2d = num(prev.off_turnovers_s2d) + num(pg.offTO);
+      const hSignals = perGameSignals(hRow, hOppRow);
+      const aSignals = perGameSignals(aRow, aOppRow);
+      const hAdvSignals = advancedSignals(hAdvRow);
+      const aAdvSignals = advancedSignals(aAdvRow);
 
-        s.def_1st_down_s2d = num(prev.def_1st_down_s2d) + num(pg.defFDAllowed);
-        s.def_total_yds_s2d = num(prev.def_total_yds_s2d) + num(pg.defTotalAllowed);
-        s.def_rush_yds_s2d = num(prev.def_rush_yds_s2d) + num(pg.defRushAllowed);
-        s.def_pass_yds_s2d = num(prev.def_pass_yds_s2d) + num(pg.defPassAllowed);
-        s.def_turnovers_s2d = num(prev.def_turnovers_s2d) + num(pg.defTO);
-        return s;
-      }
-      const hPrev = roll.get(H).get(W-1) || {};
-      const aPrev = roll.get(A).get(W-1) || {};
-      const hS2D = updateRoll(H, hPrev, hPG);
-      const aS2D = updateRoll(A, aPrev, aPG);
-      roll.get(H).set(W, hS2D);
-      roll.get(A).set(W, aS2D);
+      const hPrev = roll.get(home).get(week - 1) || {};
+      const aPrev = roll.get(away).get(week - 1) || {};
 
-      // record S2D wins/losses from schedule final
-      const fs = finalScores(g);
-      if (fs){
-        const hWin = fs.hs > fs.as ? 1 : 0;
-        const aWin = 1 - hWin;
-        hS2D.wins_s2d   = num(hPrev.wins_s2d)   + hWin;
-        hS2D.losses_s2d = num(hPrev.losses_s2d) + (1-hWin);
-        aS2D.wins_s2d   = num(aPrev.wins_s2d)   + aWin;
-        aS2D.losses_s2d = num(aPrev.losses_s2d) + (1-aWin);
+      const updateRoll = (prev, sig) => ({
+        off_1st_down_s2d: num(prev.off_1st_down_s2d) + num(sig.offFD),
+        off_total_yds_s2d: num(prev.off_total_yds_s2d) + num(sig.offTotal),
+        off_rush_yds_s2d: num(prev.off_rush_yds_s2d) + num(sig.rushYds),
+        off_pass_yds_s2d: num(prev.off_pass_yds_s2d) + num(sig.passYds),
+        off_turnovers_s2d: num(prev.off_turnovers_s2d) + num(sig.offTO),
+        def_1st_down_s2d: num(prev.def_1st_down_s2d) + num(sig.defFDAllowed),
+        def_total_yds_s2d: num(prev.def_total_yds_s2d) + num(sig.defTotalAllowed),
+        def_rush_yds_s2d: num(prev.def_rush_yds_s2d) + num(sig.defRushAllowed),
+        def_pass_yds_s2d: num(prev.def_pass_yds_s2d) + num(sig.defPassAllowed),
+        def_turnovers_s2d: num(prev.def_turnovers_s2d) + num(sig.defTO),
+        wins_s2d: num(prev.wins_s2d),
+        losses_s2d: num(prev.losses_s2d)
+      });
+
+      const hS2D = updateRoll(hPrev, hSignals);
+      const aS2D = updateRoll(aPrev, aSignals);
+      roll.get(home).set(week, hS2D);
+      roll.get(away).set(week, aS2D);
+
+      const hAdvPrev = advRoll.get(home).get(week - 1) || zeroAdvanced();
+      const aAdvPrev = advRoll.get(away).get(week - 1) || zeroAdvanced();
+      const hAdvS2D = updateAdvanced(hAdvPrev, hAdvSignals);
+      const aAdvS2D = updateAdvanced(aAdvPrev, aAdvSignals);
+      advRoll.get(home).set(week, hAdvS2D);
+      advRoll.get(away).set(week, aAdvS2D);
+
+      const scores = finalScores(game);
+      if (scores) {
+        const homeWin = scores.hs > scores.as ? 1 : 0;
+        const awayWin = 1 - homeWin;
+        hS2D.wins_s2d = num(hPrev.wins_s2d) + homeWin;
+        hS2D.losses_s2d = num(hPrev.losses_s2d) + (1 - homeWin);
+        aS2D.wins_s2d = num(aPrev.wins_s2d) + awayWin;
+        aS2D.losses_s2d = num(aPrev.losses_s2d) + (1 - awayWin);
       } else {
-        hS2D.wins_s2d   = num(hPrev.wins_s2d);
+        hS2D.wins_s2d = num(hPrev.wins_s2d);
         hS2D.losses_s2d = num(hPrev.losses_s2d);
-        aS2D.wins_s2d   = num(aPrev.wins_s2d);
+        aS2D.wins_s2d = num(aPrev.wins_s2d);
         aS2D.losses_s2d = num(aPrev.losses_s2d);
       }
 
-      const hRest = daysBetween(lastDate.get(H) || null, gd);
-      const aRest = daysBetween(lastDate.get(A) || null, gd);
-      const restDiff = (hRest||0) - (aRest||0);
+      const homeRest = daysBetween(lastDate.get(home) || null, gameDate);
+      const awayRest = daysBetween(lastDate.get(away) || null, gameDate);
+      const restDiff = (homeRest || 0) - (awayRest || 0);
 
-      const hElo = num(elo.get(H), 1500);
-      const aElo = num(elo.get(A), 1500);
-      const eloDiff = hElo - aElo;
+      const homeElo = num(elo.get(home), 1500);
+      const awayElo = num(elo.get(away), 1500);
+      const eloDiff = homeElo - awayElo;
 
-      function mkRow(team, opp, isHome, me, op){
-        // simple similar-opp placeholder (optional; can enrich later)
-        const sim_winrate_same_loc_s2d = 0;
-        const sim_pointdiff_same_loc_s2d = 0;
-        const sim_count_same_loc_s2d = 0;
-
-        const row = {
-          season, week: W, team, opponent: opp, home: isHome ? 1 : 0,
-          game_date: gd,
-
-          off_1st_down_s2d:  num(me.off_1st_down_s2d),
+      const mkRow = (team, opp, isHome, me, op, advMe, advOp) => {
+        const adv = advMe || zeroAdvanced();
+        const advOpp = advOp || zeroAdvanced();
+        return {
+          season: seasonNum,
+          week,
+          team,
+          opponent: opp,
+          home: isHome ? 1 : 0,
+          game_date: gameDate,
+          off_1st_down_s2d: num(me.off_1st_down_s2d),
           off_total_yds_s2d: num(me.off_total_yds_s2d),
-          off_rush_yds_s2d:  num(me.off_rush_yds_s2d),
-          off_pass_yds_s2d:  num(me.off_pass_yds_s2d),
+          off_rush_yds_s2d: num(me.off_rush_yds_s2d),
+          off_pass_yds_s2d: num(me.off_pass_yds_s2d),
           off_turnovers_s2d: num(me.off_turnovers_s2d),
-
-          def_1st_down_s2d:  num(me.def_1st_down_s2d),
+          def_1st_down_s2d: num(me.def_1st_down_s2d),
           def_total_yds_s2d: num(me.def_total_yds_s2d),
-          def_rush_yds_s2d:  num(me.def_rush_yds_s2d),
-          def_pass_yds_s2d:  num(me.def_pass_yds_s2d),
+          def_rush_yds_s2d: num(me.def_rush_yds_s2d),
+          def_pass_yds_s2d: num(me.def_pass_yds_s2d),
           def_turnovers_s2d: num(me.def_turnovers_s2d),
-
-          wins_s2d:   num(me.wins_s2d),
+          wins_s2d: num(me.wins_s2d),
           losses_s2d: num(me.losses_s2d),
-
-          sim_winrate_same_loc_s2d,
-          sim_pointdiff_same_loc_s2d,
-          sim_count_same_loc_s2d,
-
+          sim_winrate_same_loc_s2d: 0,
+          sim_pointdiff_same_loc_s2d: 0,
+          sim_count_same_loc_s2d: 0,
           off_total_yds_s2d_minus_opp: num(me.off_total_yds_s2d) - num(op.off_total_yds_s2d),
           def_total_yds_s2d_minus_opp: num(me.def_total_yds_s2d) - num(op.def_total_yds_s2d),
-          off_turnovers_s2d_minus_opp:  num(me.off_turnovers_s2d) -  num(op.off_turnovers_s2d),
-          def_turnovers_s2d_minus_opp:  num(me.def_turnovers_s2d) -  num(op.def_turnovers_s2d),
-
-          rest_days: isHome ? hRest : aRest,
+          off_turnovers_s2d_minus_opp: num(me.off_turnovers_s2d) - num(op.off_turnovers_s2d),
+          def_turnovers_s2d_minus_opp: num(me.def_turnovers_s2d) - num(op.def_turnovers_s2d),
+          rest_days: isHome ? homeRest : awayRest,
           rest_diff: isHome ? restDiff : -restDiff,
-          elo_pre:   isHome ? hElo : aElo,
-          elo_diff:  isHome ? eloDiff : -eloDiff,
-
-          win: winLabel(g, isHome)
+          elo_pre: isHome ? homeElo : awayElo,
+          elo_diff: isHome ? eloDiff : -eloDiff,
+          off_third_down_att_s2d: num(adv.off_third_down_att_s2d),
+          off_third_down_conv_s2d: num(adv.off_third_down_conv_s2d),
+          off_third_down_pct_s2d: num(adv.off_third_down_pct_s2d),
+          off_red_zone_att_s2d: num(adv.off_red_zone_att_s2d),
+          off_red_zone_td_s2d: num(adv.off_red_zone_td_s2d),
+          off_red_zone_td_pct_s2d: num(adv.off_red_zone_td_pct_s2d),
+          off_dropbacks_s2d: num(adv.off_dropbacks_s2d),
+          off_sacks_taken_s2d: num(adv.off_sacks_taken_s2d),
+          off_sack_rate_s2d: num(adv.off_sack_rate_s2d),
+          off_pass_att_s2d: num(adv.off_pass_att_s2d),
+          off_rush_att_s2d: num(adv.off_rush_att_s2d),
+          off_neutral_pass_rate_s2d: num(adv.off_neutral_pass_rate_s2d),
+          off_third_down_pct_s2d_minus_opp: num(adv.off_third_down_pct_s2d) - num(advOpp.off_third_down_pct_s2d),
+          off_red_zone_td_pct_s2d_minus_opp: num(adv.off_red_zone_td_pct_s2d) - num(advOpp.off_red_zone_td_pct_s2d),
+          off_sack_rate_s2d_minus_opp: num(adv.off_sack_rate_s2d) - num(advOpp.off_sack_rate_s2d),
+          off_neutral_pass_rate_s2d_minus_opp:
+            num(adv.off_neutral_pass_rate_s2d) - num(advOpp.off_neutral_pass_rate_s2d),
+          win: winLabel(game, isHome)
         };
-        return row;
+      };
+
+      const homeRow = mkRow(home, away, true, hS2D, aS2D, hAdvS2D, aAdvS2D);
+      const awayRow = mkRow(away, home, false, aS2D, hS2D, aAdvS2D, hAdvS2D);
+      out.push(homeRow, awayRow);
+
+      if (gameDate) {
+        lastDate.set(home, gameDate);
+        lastDate.set(away, gameDate);
       }
 
-      const hBuilt = mkRow(H, A, true,  hS2D, aS2D);
-      const aBuilt = mkRow(A, H, false, aS2D, hS2D);
-      out.push(hBuilt, aBuilt);
-
-      if (gd){ lastDate.set(H, gd); lastDate.set(A, gd); }
-
-      const fs2 = finalScores(g);
-      if (fs2){
-        // tiny Elo update
+      if (scores) {
         const K = 2.5;
-        const expectedH = 1/(1+Math.pow(10, -(hElo - aElo)/400));
-        const outcomeH = fs2.hs > fs2.as ? 1 : 0;
-        const d = K*(outcomeH - expectedH);
-        elo.set(H, hElo + d); elo.set(A, aElo - d);
+        const expectedHome = 1 / (1 + Math.pow(10, -(homeElo - awayElo) / 400));
+        const outcomeHome = scores.hs > scores.as ? 1 : 0;
+        const delta = K * (outcomeHome - expectedHome);
+        elo.set(home, homeElo + delta);
+        elo.set(away, awayElo - delta);
       }
-
-      if (hBuilt.win===0 || hBuilt.win===1) rowsSoFar.push(hBuilt);
-      if (aBuilt.win===0 || aBuilt.win===1) rowsSoFar.push(aBuilt);
     }
   }
 
   return out;
 }
-
-export { FEATS };

--- a/trainer/model_bt.js
+++ b/trainer/model_bt.js
@@ -190,7 +190,7 @@ export function predictBT({
         Number(hAvg.turnovers ?? 0) - Number(aAvg.turnovers ?? 0),
         Number(hAvg.possession_seconds ?? 0) - Number(aAvg.possession_seconds ?? 0),
         Number(hAvg.r_ratio ?? 0) - Number(aAvg.r_ratio ?? 0),
-        Number(row.features?.delta_power_rank ?? 0)
+        Number(row.features?.diff_elo_pre ?? 0)
       ];
       const std = applyScaler([featVec], scaler)[0];
       const prob = sigmoid(std.reduce((s, v, idx) => s + v * coeffs[idx], 0) + model.b);

--- a/trainer/tests/smoke.js
+++ b/trainer/tests/smoke.js
@@ -34,6 +34,21 @@ function makeTeamRow(season, week, team, opponent, totalYards, passYards, penalt
   };
 }
 
+function makeTeamGameRow(season, week, team, thirdAtt, thirdConv, redAtt, redTd, passAtt, rushAtt, sacksTaken) {
+  return {
+    season,
+    week,
+    team,
+    third_down_att: thirdAtt,
+    third_down_conv: thirdConv,
+    red_zone_att: redAtt,
+    red_zone_td: redTd,
+    pass_att: passAtt,
+    rush_att: rushAtt,
+    sacks_taken: sacksTaken
+  };
+}
+
 async function main() {
   const season = 2023;
   const schedules = [
@@ -45,6 +60,7 @@ async function main() {
     makeGame(season, 3, "B", "C", 24, 17)
   ];
   const teamWeekly = [];
+  const teamGame = [];
   for (const game of schedules) {
     const base = 350 + (game.week * 10);
     teamWeekly.push(
@@ -53,12 +69,18 @@ async function main() {
     teamWeekly.push(
       makeTeamRow(season, game.week, game.away_team, game.home_team, base - 30, base - 150, 45, 2, "29:30")
     );
+    const thirdAttHome = 12 + game.week;
+    const thirdAttAway = 11 + game.week;
+    teamGame.push(
+      makeTeamGameRow(season, game.week, game.home_team, thirdAttHome, Math.floor(thirdAttHome * 0.5), 5 + game.week, 3 + game.week, 32 + game.week, 28 + game.week, 2),
+      makeTeamGameRow(season, game.week, game.away_team, thirdAttAway, Math.floor(thirdAttAway * 0.45), 4 + game.week, 2 + game.week, 30 + game.week, 30 + game.week, 3)
+    );
   }
 
   const result = await runTraining({
     season,
     week: 3,
-    data: { schedules, teamWeekly, prevTeamWeekly: [] },
+    data: { schedules, teamWeekly, teamGame, prevTeamWeekly: [] },
     options: {
       btBootstrapSamples: 20,
       annSeeds: 3,


### PR DESCRIPTION
## Summary
- load nflverse team_game datasets to capture third-down, red-zone, and pass/run situational stats
- extend feature builders to accumulate advanced season-to-date metrics with opponent differentials and updated BT differentials
- refresh training pipelines, narratives, and smoke test to consume the richer features and provide league-relative context

## Testing
- `node trainer/tests/smoke.js`


------
https://chatgpt.com/codex/tasks/task_e_68db17a7332083308b52268f8b4c80c3