### PR TITLE
Add EPA and usage features with metrics tracking

### DIFF
--- a/trainer/dataSources.js
+++ b/trainer/dataSources.js
@@ -9,6 +9,8 @@ import { gunzipSync } from "node:zlib"; // <-- use Node built-in zlib
 const NFLVERSE_RELEASE = "https://github.com/nflverse/nflverse-data/releases/download";
 const STATS_TEAM_TAG = "stats_team";
 const TEAM_GAME_TAG = "team_game";
+const PBP_TAG = "pbp";
+const PLAYER_WEEKLY_TAG = "player_stats";
 const SCHEDULES_URL = "https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv";
 
 function parseCSV(text) {
@@ -41,9 +43,25 @@ async function fetchCSVMaybeGz(url) {
   throw new Error(`Unsupported extension for ${url}`);
 }
 
+function inferRoofFlags(row = {}) {
+  const rawRoof =
+    row.roof ?? row.stadium_type ?? row.venue_type ?? row.roof_type ?? row.stadium_roof ?? row.venue_roof;
+  if (rawRoof == null || rawRoof === "") {
+    return { is_dome: null, is_outdoor: null };
+  }
+  const roof = String(rawRoof).toLowerCase();
+  const isDome = /dome|indoor/.test(roof);
+  const isOutdoor = /outdoor|open/.test(roof);
+  return { is_dome: isDome ? 1 : 0, is_outdoor: isOutdoor ? 1 : 0 };
+}
+
 export async function loadSchedules() {
   const text = await fetchText(SCHEDULES_URL);
-  return parseCSV(text);
+  const rows = parseCSV(text);
+  return rows.map((row) => {
+    const flags = inferRoofFlags(row);
+    return { ...row, ...flags };
+  });
 }
 
 export async function loadTeamWeekly(season) {
@@ -93,5 +111,60 @@ export async function loadTeamGameAdvanced(season) {
   if (lastErr) {
     console.warn(`loadTeamGameAdvanced(${season}) fell back to empty dataset: ${lastErr?.message}`);
   }
+  return [];
+}
+
+export async function loadPBP(season) {
+  const suffixes = [
+    `play_by_play_${season}.csv.gz`,
+    `play_by_play_${season}.csv`
+  ];
+  const releaseCandidates = suffixes.map((s) => `${NFLVERSE_RELEASE}/${PBP_TAG}/${s}`);
+  const rawBases = [
+    "https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/play_by_play",
+    "https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/play_by_play",
+    "https://raw.githubusercontent.com/nflverse/nfldata/master/data/play_by_play"
+  ];
+  const rawCandidates = rawBases.flatMap((base) => suffixes.map((s) => `${base}/${s}`));
+  const candidates = [...releaseCandidates, ...rawCandidates];
+  for (const url of candidates) {
+    try {
+      const rows = await fetchCSVMaybeGz(url);
+      if (Array.isArray(rows) && rows.length) return rows;
+    } catch (err) {
+      // ignore and try next candidate
+    }
+  }
+  console.warn(`loadPBP(${season}) fell back to empty dataset`);
+  return [];
+}
+
+export async function loadPlayerWeekly(season) {
+  const suffixes = [
+    `player_stats_weekly_${season}.csv.gz`,
+    `player_stats_weekly_${season}.csv`,
+    `player_stats_${season}.csv.gz`,
+    `player_stats_${season}.csv`
+  ];
+  const releaseCandidates = suffixes.map((s) => `${NFLVERSE_RELEASE}/${PLAYER_WEEKLY_TAG}/${s}`);
+  const rawBases = [
+    "https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/player_stats_weekly",
+    "https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/player_stats_weekly",
+    "https://raw.githubusercontent.com/nflverse/nfldata/master/data/player_stats_weekly",
+    "https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/player_stats",
+    "https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/player_stats",
+    "https://raw.githubusercontent.com/nflverse/nfldata/master/data/player_stats"
+  ];
+  const rawCandidates = rawBases.flatMap((base) => suffixes.map((s) => `${base}/${s}`));
+  const candidates = [...releaseCandidates, ...rawCandidates];
+  for (const url of candidates) {
+    try {
+      const rows = await fetchCSVMaybeGz(url);
+      if (Array.isArray(rows) && rows.length) return rows;
+    } catch (err) {
+      // ignore and continue
+    }
+  }
+  console.warn(`loadPlayerWeekly(${season}) fell back to empty dataset`);
   return [];
 }

--- a/trainer/featureBuild_pbp.js
+++ b/trainer/featureBuild_pbp.js
@@ -1,0 +1,92 @@
+// trainer/featureBuild_pbp.js
+// Aggregate play-by-play rows into team-week level EPA and success rate metrics.
+
+const isReg = (v) => {
+  if (v == null) return true;
+  const s = String(v).trim().toUpperCase();
+  return s === "" || s.startsWith("REG");
+};
+
+const num = (value, def = 0) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : def;
+};
+
+const normTeam = (value) => {
+  if (!value) return null;
+  const s = String(value).trim().toUpperCase();
+  return s || null;
+};
+
+function ensure(map, key) {
+  if (!map.has(key)) {
+    map.set(key, {
+      off_plays: 0,
+      off_epa_sum: 0,
+      off_success_sum: 0,
+      def_plays: 0,
+      def_epa_sum: 0,
+      def_success_sum: 0
+    });
+  }
+  return map.get(key);
+}
+
+const successValue = (raw, fallback) => {
+  if (raw === true) return 1;
+  if (raw === false) return 0;
+  const n = Number(raw);
+  if (Number.isFinite(n)) return n > 0 ? 1 : 0;
+  return fallback;
+};
+
+export function aggregatePBP({ rows = [], season }) {
+  const seasonNum = Number(season);
+  const out = new Map();
+  if (!Number.isFinite(seasonNum)) return out;
+
+  for (const row of rows) {
+    if (Number(row.season) !== seasonNum) continue;
+    if (!isReg(row.season_type)) continue;
+    const week = Number(row.week ?? row.game_week ?? row.week_number);
+    if (!Number.isFinite(week)) continue;
+
+    const posteam = normTeam(row.posteam ?? row.offense ?? row.offense_team);
+    const defteam = normTeam(row.defteam ?? row.defense ?? row.defense_team);
+    const epa = num(row.epa, 0);
+    const success = successValue(row.success, epa > 0 ? 1 : 0);
+
+    if (posteam) {
+      const key = `${seasonNum}-${week}-${posteam}`;
+      const rec = ensure(out, key);
+      rec.off_plays += 1;
+      rec.off_epa_sum += epa;
+      rec.off_success_sum += success;
+    }
+
+    if (defteam) {
+      const key = `${seasonNum}-${week}-${defteam}`;
+      const rec = ensure(out, key);
+      rec.def_plays += 1;
+      rec.def_epa_sum += epa;
+      rec.def_success_sum += success;
+    }
+  }
+
+  for (const [key, rec] of out.entries()) {
+    const offPlays = rec.off_plays || 0;
+    const defPlays = rec.def_plays || 0;
+    out.set(key, {
+      off_epa_per_play: offPlays ? rec.off_epa_sum / offPlays : 0,
+      off_success_rate: offPlays ? rec.off_success_sum / offPlays : 0,
+      off_play_weight: offPlays,
+      def_epa_per_play_allowed: defPlays ? rec.def_epa_sum / defPlays : 0,
+      def_success_rate_allowed: defPlays ? rec.def_success_sum / defPlays : 0,
+      def_play_weight: defPlays
+    });
+  }
+
+  return out;
+}
+
+export default aggregatePBP;

--- a/trainer/featureBuild_players.js
+++ b/trainer/featureBuild_players.js
@@ -1,0 +1,127 @@
+// trainer/featureBuild_players.js
+// Aggregate player-week data into team usage metrics.
+
+const isReg = (v) => {
+  if (v == null) return true;
+  const s = String(v).trim().toUpperCase();
+  return s === "" || s.startsWith("REG");
+};
+
+const num = (value, def = 0) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : def;
+};
+
+const normTeam = (value) => {
+  if (!value) return null;
+  const s = String(value).trim().toUpperCase();
+  return s || null;
+};
+
+const normPos = (value) => {
+  if (!value) return "";
+  return String(value).trim().toUpperCase();
+};
+
+function ensure(map, key) {
+  if (!map.has(key)) {
+    map.set(key, {
+      team_rush_att: 0,
+      rb_rush_att: 0,
+      total_targets: 0,
+      wr_targets: 0,
+      te_targets: 0,
+      qb_pass_att: 0,
+      qb_air_yards: 0,
+      qb_pass_yards: 0,
+      qb_sacks: 0
+    });
+  }
+  return map.get(key);
+}
+
+const pick = (row, keys, def = 0) => {
+  for (const key of keys) {
+    if (row[key] != null && row[key] !== "") return row[key];
+  }
+  return def;
+};
+
+export function aggregatePlayerUsage({ rows = [], season }) {
+  const seasonNum = Number(season);
+  const out = new Map();
+  if (!Number.isFinite(seasonNum)) return out;
+
+  for (const row of rows) {
+    if (Number(row.season) !== seasonNum) continue;
+    if (!isReg(row.season_type)) continue;
+    const week = Number(row.week ?? row.game_week ?? row.week_number);
+    if (!Number.isFinite(week)) continue;
+
+    const team = normTeam(row.recent_team ?? row.team ?? row.team_abbr ?? row.posteam);
+    if (!team) continue;
+
+    const pos = normPos(row.position ?? row.player_position ?? row.pos);
+    const key = `${seasonNum}-${week}-${team}`;
+    const rec = ensure(out, key);
+
+    const rushAtt = num(
+      pick(row, ["rushing_attempts", "rush_attempts", "carries", "rushing_att", "rush_att"]),
+      0
+    );
+    const targets = num(pick(row, ["targets", "receiving_targets", "rec_targets", "target"], 0), 0);
+    const passAtt = num(
+      pick(row, ["pass_attempts", "passing_attempts", "attempts", "attempts_pass", "att_pass"]),
+      0
+    );
+    const airYards = num(
+      pick(row, ["air_yards", "passing_air_yards", "pass_air_yards", "air_yds"], 0),
+      0
+    );
+    const passYds = num(pick(row, ["passing_yards", "pass_yards", "pass_yds"], 0), 0);
+    const sacks = num(pick(row, ["sacks", "qb_sacked", "sacked", "sacks_taken"], 0), 0);
+
+    rec.team_rush_att += rushAtt;
+    rec.total_targets += targets;
+
+    if (pos === "RB") {
+      rec.rb_rush_att += rushAtt;
+    }
+    if (pos === "WR") {
+      rec.wr_targets += targets;
+    }
+    if (pos === "TE") {
+      rec.te_targets += targets;
+    }
+    if (pos === "QB") {
+      rec.qb_pass_att += passAtt;
+      rec.qb_air_yards += airYards;
+      rec.qb_pass_yards += passYds;
+      rec.qb_sacks += sacks;
+    }
+  }
+
+  for (const [key, rec] of out.entries()) {
+    const rushTotal = rec.team_rush_att || 0;
+    const targetTotal = rec.total_targets || 0;
+    const qbAtt = rec.qb_pass_att || 0;
+    const dropbacks = qbAtt + (rec.qb_sacks || 0);
+    const airBasis = rec.qb_air_yards || rec.qb_pass_yards || 0;
+
+    out.set(key, {
+      rb_rush_share: rushTotal ? rec.rb_rush_att / rushTotal : 0,
+      rb_rush_weight: rushTotal,
+      wr_target_share: targetTotal ? rec.wr_targets / targetTotal : 0,
+      te_target_share: targetTotal ? rec.te_targets / targetTotal : 0,
+      target_weight: targetTotal,
+      qb_aypa: qbAtt ? airBasis / qbAtt : 0,
+      qb_aypa_weight: qbAtt,
+      qb_sack_rate: dropbacks ? rec.qb_sacks / dropbacks : 0,
+      qb_sack_rate_weight: dropbacks
+    });
+  }
+
+  return out;
+}
+
+export default aggregatePlayerUsage;

--- a/trainer/metrics.js
+++ b/trainer/metrics.js
@@ -1,0 +1,121 @@
+// trainer/metrics.js
+// Lightweight metric helpers for binary classification.
+
+export function logLoss(yTrue = [], probs = []) {
+  if (!Array.isArray(yTrue) || yTrue.length === 0) return null;
+  const eps = 1e-12;
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < yTrue.length; i++) {
+    const y = Number(yTrue[i]);
+    const p = Number(probs[i]);
+    if (!Number.isFinite(y) || !Number.isFinite(p)) continue;
+    const clipped = Math.min(Math.max(p, eps), 1 - eps);
+    sum += -(y * Math.log(clipped) + (1 - y) * Math.log(1 - clipped));
+    count += 1;
+  }
+  return count ? sum / count : null;
+}
+
+export function brier(yTrue = [], probs = []) {
+  if (!Array.isArray(yTrue) || yTrue.length === 0) return null;
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < yTrue.length; i++) {
+    const y = Number(yTrue[i]);
+    const p = Number(probs[i]);
+    if (!Number.isFinite(y) || !Number.isFinite(p)) continue;
+    const diff = p - y;
+    sum += diff * diff;
+    count += 1;
+  }
+  return count ? sum / count : null;
+}
+
+export function accuracy(yTrue = [], probs = [], threshold = 0.5) {
+  if (!Array.isArray(yTrue) || yTrue.length === 0) return null;
+  let correct = 0;
+  let count = 0;
+  for (let i = 0; i < yTrue.length; i++) {
+    const y = Number(yTrue[i]);
+    const p = Number(probs[i]);
+    if (!Number.isFinite(y) || !Number.isFinite(p)) continue;
+    const pred = p >= threshold ? 1 : 0;
+    if (pred === y) correct += 1;
+    count += 1;
+  }
+  return count ? correct / count : null;
+}
+
+export function aucRoc(yTrue = [], probs = []) {
+  if (!Array.isArray(yTrue) || yTrue.length === 0) return null;
+  const pairs = [];
+  for (let i = 0; i < yTrue.length; i++) {
+    const y = Number(yTrue[i]);
+    const p = Number(probs[i]);
+    if (!Number.isFinite(y) || !Number.isFinite(p)) continue;
+    pairs.push({ y, p });
+  }
+  if (!pairs.length) return null;
+  const pos = pairs.filter((r) => r.y === 1).length;
+  const neg = pairs.length - pos;
+  if (!pos || !neg) return null;
+
+  pairs.sort((a, b) => a.p - b.p);
+  let rank = 1;
+  let sumRanksPos = 0;
+  for (let i = 0; i < pairs.length; ) {
+    let j = i + 1;
+    while (j < pairs.length && pairs[j].p === pairs[i].p) j += 1;
+    const avgRank = (rank + (rank + (j - i) - 1)) / 2;
+    for (let k = i; k < j; k++) {
+      if (pairs[k].y === 1) sumRanksPos += avgRank;
+    }
+    rank += j - i;
+    i = j;
+  }
+  return (sumRanksPos - (pos * (pos + 1)) / 2) / (pos * neg);
+}
+
+export function calibrationBins(yTrue = [], probs = [], bins = 10) {
+  if (!Array.isArray(yTrue) || yTrue.length === 0) return [];
+  const records = Array.from({ length: bins }, (_, idx) => ({
+    bin: idx,
+    lower: idx / bins,
+    upper: (idx + 1) / bins,
+    sumP: 0,
+    sumY: 0,
+    n: 0
+  }));
+
+  for (let i = 0; i < yTrue.length; i++) {
+    const y = Number(yTrue[i]);
+    const p = Number(probs[i]);
+    if (!Number.isFinite(y) || !Number.isFinite(p)) continue;
+    const clipped = Math.min(Math.max(p, 0), 1);
+    const idx = Math.min(bins - 1, Math.floor(clipped * bins));
+    const rec = records[idx];
+    rec.sumP += clipped;
+    rec.sumY += y;
+    rec.n += 1;
+  }
+
+  return records
+    .filter((rec) => rec.n > 0)
+    .map((rec) => ({
+      bin: rec.bin,
+      lower: rec.lower,
+      upper: rec.upper,
+      p_mean: rec.sumP / rec.n,
+      y_rate: rec.sumY / rec.n,
+      n: rec.n
+    }));
+}
+
+export default {
+  logLoss,
+  brier,
+  accuracy,
+  aucRoc,
+  calibrationBins
+};


### PR DESCRIPTION
## Summary
- load nflverse play-by-play and player usage datasets along with inferred roof flags for schedule rows
- extend the feature builder with EPA/success rate and usage rolling metrics plus new helper modules
- add shared metrics utilities and update the training pipeline to emit outcomes and metrics artifacts

## Testing
- npm run train:multi *(fails: proxy redirect limit)*

------
https://chatgpt.com/codex/tasks/task_e_68db24b45cc0833087cc93911c9ef50f