### PR TITLE
Update schedule data loader to use nfldata mirror

### DIFF
--- a/trainer/dataSources.js
+++ b/trainer/dataSources.js
@@ -59,11 +59,14 @@ function currentYear() {
 // Schedules/games (stable in repo tree)
 export async function loadSchedules() {
   const CANDIDATES = [
+    // Primary mirror maintained by nflverse since 2024 realignment
+    "https://raw.githubusercontent.com/nflverse/nfldata/main/data/games.csv",
+    "https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv",
     "https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/games.csv",
     "https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/games.csv"
   ];
   const txt = await tryFirst(CANDIDATES);
-  if (!txt) throw new Error("Could not load schedules (games.csv) from nflverse-data");
+  if (!txt) throw new Error("Could not load schedules (games.csv) from nflverse mirrors");
   return parseCsvLoose(txt);
 }
 


### PR DESCRIPTION
## Summary
- include the nfldata repository as the primary mirror when downloading games.csv
- update the fallback error message to reflect the wider set of nflverse mirrors

## Testing
- node -e "import('./trainer/dataSources.js').then(m => m.loadSchedules())" *(fails in container: outbound network for node fetch is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68db2f47d1f8833095b8e8225e1f691d