### PR TITLE
Add context and explain artifacts plus worker routes

### DIFF
--- a/.github/workflows/train.yaml
+++ b/.github/workflows/train.yaml
@@ -24,6 +24,7 @@ jobs:
 
     env:
       NODE_VERSION: 20.x
+      LOG_LEVEL: warn
 
     steps:
       - name: Checkout

--- a/trainer/contextPack.js
+++ b/trainer/contextPack.js
@@ -1,0 +1,239 @@
+// trainer/contextPack.js
+// Builds per-game context for a week: injuries, QB form, rolling team strength, venue, Elo/spread.
+
+import {
+  loadSchedules, loadTeamWeekly, loadPlayerWeekly, loadRostersWeekly,
+  loadDepthCharts, loadInjuries, loadPFRAdvTeam, loadESPNQBR
+} from "./dataSources.js";
+import { loadElo } from "./eloLoader.js";
+
+export async function buildContextForWeek(season, week) {
+  const [schedAll, teamW, playersW, rostersW, depthW, injuriesW, pfrTeam, qbr, elo] = await Promise.all([
+    loadSchedules(),
+    loadTeamWeekly(season),
+    loadPlayerWeekly(season),
+    loadRostersWeekly(season),
+    loadDepthCharts(season),
+    loadInjuries(season),
+    loadPFRAdvTeam(season),
+    loadESPNQBR(season),
+    loadElo(season)
+  ]);
+
+  // Filter schedule rows for the exact week/season
+  const sched = schedAll.filter(r => Number(r.season)===season && Number(r.week)===week);
+  const teamKey = (t,w)=> `${t}:${season}:${w}`;
+
+  // Index team weekly by (team,week)
+  const teamMap = new Map();
+  for (const r of teamW) {
+    const t = r.team || r.team_abbr || r.posteam || r.recent_team;
+    const w = Number(r.week);
+    if (!t || !Number.isFinite(w) || Number(r.season)!==season) continue;
+    teamMap.set(teamKey(t,w), r);
+  }
+
+  // Players: group last 3 games per team for QB form
+  const playersByTeam = groupPlayerWeekly(playersW, season);
+  // Injuries, depth charts, rosters → star/out lists
+  const injuryIndex = indexInjuries(injuriesW, season, week);
+  const startersIdx  = indexStarters(depthW, rostersW, season, week);
+  // ESPN QBR indexed by team (some CSVs have team or player_id)
+  const qbrByTeam = indexQBR(qbr, season);
+
+  // Elo by game_id
+  const eloByGame = indexElo(elo, season);
+
+  const out = [];
+  for (const g of sched) {
+    const home = g.home_team, away = g.away_team;
+    const homeKey = (home || "").toUpperCase();
+    const awayKey = (away || "").toUpperCase();
+    const game_id = `${season}-W${String(week).padStart(2,"0")}-${home}-${away}`;
+
+    const rsHome = rollingTeamStrength(teamMap, home, season, week, 3);
+    const rsAway = rollingTeamStrength(teamMap, away, season, week, 3);
+
+    const qbHome = qbForm(playersByTeam[home]?.last3, qbrByTeam[homeKey]);
+    const qbAway = qbForm(playersByTeam[away]?.last3, qbrByTeam[awayKey]);
+
+    const injHome = injuryIndex.get(homeKey) || { out:[], probable:[] };
+    const injAway = injuryIndex.get(awayKey) || { out:[], probable:[] };
+
+    // mark starters as star=true for impact
+    markStarters(injHome, startersIdx.get(homeKey));
+    markStarters(injAway, startersIdx.get(awayKey));
+
+    const roof = (g.roof || g.roof_type || "").toLowerCase();
+    const surfaceSrc = (g.surface || g.surface_short || "").toLowerCase();
+    const surface = surfaceSrc.includes("turf") ? "turf" : surfaceSrc.includes("grass") ? "grass" : "unknown";
+    const is_dome = /dome|closed/.test(roof);
+    const is_outdoor = /outdoor|open/.test(roof);
+
+    const eloG = eloByGame.get(game_id) || null;
+
+    out.push({
+      game_id, season, week, home_team: home, away_team: away,
+      context: {
+        injuries: {
+          home_out: injHome.out,
+          away_out: injAway.out,
+          home_probable: injHome.probable,
+          away_probable: injAway.probable
+        },
+        qb_form: { home: qbHome, away: qbAway },
+        rolling_strength: { home: rsHome, away: rsAway },
+        venue: { is_dome, is_outdoor, surface },
+        elo: eloG ? { home: eloG.home, away: eloG.away, diff: eloG.diff, spread_home: eloG.spread_home ?? null } : null,
+        market: eloG && Number.isFinite(eloG.spread_home) ? { spread_home: eloG.spread_home } : null
+      }
+    });
+  }
+  return out;
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+function groupPlayerWeekly(rows, season) {
+  const byTeam = {};
+  for (const r of rows) {
+    if (Number(r.season)!==season) continue;
+    const t = r.team || r.recent_team || r.team_abbr; if (!t) continue;
+    (byTeam[t] ||= []).push(r);
+  }
+  const out = {};
+  for (const [t, arr] of Object.entries(byTeam)) {
+    arr.sort((a,b)=> Number(a.week)-Number(b.week));
+    const qbs = arr.filter(x => (x.position||x.pos||"").toUpperCase()==="QB");
+    out[t] = { last3: qbs.slice(-3) };
+  }
+  return out;
+}
+
+function qbForm(last3, qbrTeam) {
+  // Primary: last-3 YPA & sack rate; augment with QBR if available
+  if (!last3 || !last3.length) return { ypa_3g: 0, sack_rate_3g: 0, qbr: qbrTeam ?? null };
+  let att=0, yds=0, sacks=0, dropbacks=0;
+  for (const r of last3) {
+    const pa = Number(r.pass_attempts || r.attempts || r.c_att || 0);
+    const y = Number(r.passing_yards || r.pass_yds || r.yards || 0);
+    const sk = Number(r.sacks || r.sacks_taken || 0);
+    att+=pa; yds+=y; sacks+=sk; dropbacks+=(pa+sk);
+  }
+  const ypa = att? yds/att : 0;
+  const sr = dropbacks? sacks/dropbacks : 0;
+  return { ypa_3g: round4(ypa), sack_rate_3g: round4(sr), qbr: qbrTeam ?? null };
+}
+
+function rollingTeamStrength(teamMap, team, season, week, k) {
+  const rows=[]; for (let w=week-1; w>=1 && rows.length<k; w--) {
+    const r = teamMap.get(`${team}:${season}:${w}`); if (r) rows.push(r);
+  }
+  let yfor=0, yagainst=0;
+  for (const r of rows) {
+    yfor += Number(r.total_yards || r.off_total_yards || r.off_total_yds || 0);
+    yagainst += Number(r.total_yards_allowed || r.def_total_yards || r.def_total_yds || 0);
+  }
+  return { yds_for_3g:yfor, yds_against_3g:yagainst, net_yds_3g:yfor-yagainst };
+}
+
+function indexElo(rows, season) {
+  const m = new Map();
+  for (const r of rows) {
+    if (Number(r.season)!==season) continue;
+    const home = r.home_team || r.home, away = r.away_team || r.away, week = Number(r.week);
+    if (!home||!away||!week) continue;
+    const game_id = `${season}-W${String(week).padStart(2,"0")}-${home}-${away}`;
+    const homeE = Number(r.elo_home || r.home_elo || r.elo_pre_home || 0);
+    const awayE = Number(r.elo_away || r.away_elo || r.elo_pre_away || 0);
+    const diff = homeE - awayE;
+    const spread_home = (r.spread_home!=null) ? Number(r.spread_home) :
+                        (r.spread!=null) ? Number(r.spread) : null;
+    m.set(game_id, { home: homeE, away: awayE, diff, ...(Number.isFinite(spread_home)?{spread_home}: {}) });
+  }
+  return m;
+}
+
+function indexQBR(rows, season) {
+  // Many QBR tables have columns like season, team, qbr_total or qbr
+  const out = {};
+  for (const r of rows) {
+    if (Number(r.season)!==season) continue;
+    const t = (r.team || r.team_abbr || "").toUpperCase(); if (!t) continue;
+    const qbr = Number(r.qbr_total || r.qbr || r.total_qbr || 0);
+    if (!Number.isFinite(qbr)) continue;
+    // Keep latest entry or max
+    out[t] = qbr;
+  }
+  return out;
+}
+
+function indexInjuries(rows, season, week) {
+  // Expect columns like season, week, team, player, position, status
+  const key = t => `${t}`;
+  const out = new Map();
+  const OUT_STATI = new Set(["OUT","IR","PUP","SUSP","RESERVED"]);
+  const PRB_STATI = new Set(["QUESTIONABLE","DOUBTFUL","PROBABLE","LIMITED"]);
+
+  for (const r of rows) {
+    if (Number(r.season)!==season) continue;
+    const w = Number(r.week); if (!Number.isFinite(w) || w>week) continue;
+    const team = (r.team || r.team_abbr || "").toUpperCase(); if (!team) continue;
+    const status = (r.status || r.injury_status || "").toUpperCase();
+    const pos = (r.position || r.pos || "").toUpperCase();
+    const player = r.player || r.player_name || r.gsis_id || "unknown";
+    const row = { player, pos, note: status, star: false };
+
+    const bucket = (OUT_STATI.has(status) || status==="DNP") ? "out" :
+                   PRB_STATI.has(status) ? "probable" : null;
+    if (!bucket) continue;
+    const v = out.get(key(team)) || { out:[], probable:[] };
+    v[bucket].push(row);
+    out.set(key(team), v);
+  }
+  return out;
+}
+
+function indexStarters(depthCharts, rosters, season, week) {
+  // Very light starter index: depth_charts with depth==1 at this week, fallback to roster starters if present
+  const starters = new Map(); // key: team -> Set of player names
+  const byTeam = new Map();
+
+  for (const r of depthCharts) {
+    if (Number(r.season)!==season) continue;
+    const w = Number(r.week); if (!Number.isFinite(w) || w>week) continue;
+    const team = (r.team || r.team_abbr || "").toUpperCase(); if (!team) continue;
+    const depth = Number(r.depth || r.player_depth || 0);
+    const player = r.player || r.player_name || r.gsis_id || "";
+    if (depth === 1 && player) {
+      (byTeam.get(team) || byTeam.set(team, new Set()).get(team)).add(player);
+    }
+  }
+  // fallback: rosters weekly (starter flag sometimes provided)
+  for (const r of rosters) {
+    if (Number(r.season)!==season) continue;
+    const w = Number(r.week); if (!Number.isFinite(w) || w>week) continue;
+    const team = (r.team || r.team_abbr || r.recent_team || "").toUpperCase(); if (!team) continue;
+    const player = r.player || r.player_name || r.gsis_id || "";
+    const starter = (String(r.starter || r.depth || "").toLowerCase()==="true" || String(r.depth||"")==="1");
+    if (starter && player) {
+      (byTeam.get(team) || byTeam.set(team, new Set()).get(team)).add(player);
+    }
+  }
+  // finalize
+  for (const [t,set] of byTeam.entries()) starters.set(t, Array.from(set));
+  return starters;
+}
+
+function markStarters(injBucket, startersArray) {
+  if (!injBucket || !startersArray) return;
+  const starters = new Set(startersArray.map(s=>String(s).toLowerCase()));
+  for (const k of ["out","probable"]) {
+    for (const p of injBucket[k] || []) {
+      const nm = String(p.player||"").toLowerCase();
+      if (starters.has(nm) || p.pos === "QB") p.star = true;
+    }
+  }
+}
+
+function round4(x){ return Math.round(x*1e4)/1e4; }

--- a/trainer/dataSources.js
+++ b/trainer/dataSources.js
@@ -1,7 +1,10 @@
 // trainer/dataSources.js
-// Robust, URL-tolerant loaders for nflverse datasets via GitHub Releases first.
-// ESM module. Node 18+ global fetch is available.
+// Fetches nflverse datasets via GitHub Releases with raw fallbacks.
+// Keep all functions idempotent and tolerant to missing optional sources.
 
+import { gunzipSync } from "node:zlib";
+
+// ---- logging ---------------------------------------------------------------
 const LOG_LEVEL = (process.env.LOG_LEVEL || "info").toLowerCase();
 function log(level, ...args) {
   const rank = { silent:0, warn:1, info:2, debug:3 }[LOG_LEVEL] ?? 2;
@@ -9,131 +12,208 @@ function log(level, ...args) {
   if (need <= rank) console[level === "warn" ? "warn" : "log"](...args);
 }
 
+function yearNow(){ return new Date().getUTCFullYear(); }
+
+// ---- fetch helpers ---------------------------------------------------------
 async function fetchText(url) {
-  const res = await fetch(url, {
-    redirect: "follow",
-    headers: { "User-Agent": "nfl-wins-free-stack/1.0 (+actions)" }
-  });
+  const res = await fetch(url, { redirect: "follow", headers: { "User-Agent": "nfl-wins/1.0 (+actions)" } });
   if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
   return await res.text();
 }
-
-async function tryFirst(urls) {
+async function fetchBuffer(url) {
+  const res = await fetch(url, { redirect: "follow", headers: { "User-Agent": "nfl-wins/1.0 (+actions)" } });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  const ab = await res.arrayBuffer();
+  return Buffer.from(ab);
+}
+async function tryFirst(urls, binary=false) {
   for (const url of urls) {
     try {
-      const txt = await fetchText(url);
+      const out = binary ? await fetchBuffer(url) : await fetchText(url);
       log("info", `OK ${url}`);
-      return txt;
+      return out;
     } catch (e) {
-      const msg = String(e.message || e);
-      if (msg.includes("HTTP 404")) {
-        log("debug", `404 ${url}`);
-        continue;
-      }
-      log("warn", `warn: ${msg}`);
-      continue;
+      const m = String(e?.message||e);
+      if (m.includes("HTTP 404")) { log("debug", `404 ${url}`); continue; }
+      log("warn", `warn: ${m}`);
     }
   }
   return null;
 }
 
+// ---- CSV parsers -----------------------------------------------------------
 function parseCsvLoose(txt) {
+  // Lightweight CSV splitter (no quotes support). Enough for most nflverse CSVs we use here.
   const lines = txt.trim().split(/\r?\n/);
-  if (lines.length === 0) return [];
+  if (!lines.length) return [];
   const header = lines[0].split(",");
   return lines.slice(1).map(line => {
     const cols = line.split(",");
-    const obj = {};
-    for (let i = 0; i < header.length; i++) obj[header[i]] = cols[i] ?? "";
-    return obj;
+    const o = {};
+    for (let i=0;i<header.length;i++) o[header[i]] = cols[i] ?? "";
+    return o;
   });
 }
 
-function currentYear() {
-  const now = new Date();
-  return now.getUTCFullYear();
-}
+// ---- URL builders / sources ------------------------------------------------
+const BASE_REL = "https://github.com/nflverse/nflverse-data/releases/download";
+const RAW_MAIN  = "https://raw.githubusercontent.com/nflverse/nflverse-data/main";
+const RAW_MAST  = "https://raw.githubusercontent.com/nflverse/nflverse-data/master";
 
-// ---- PUBLIC LOADERS ----
-
-// Schedules/games (stable in repo tree)
+// Schedules (all-years CSV; filter season in code)
 export async function loadSchedules() {
-  const CANDIDATES = [
-    // Primary mirror maintained by nflverse since 2024 realignment
-    "https://raw.githubusercontent.com/nflverse/nfldata/main/data/games.csv",
-    "https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv",
-    "https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/games.csv",
-    "https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/games.csv"
+  const C = [
+    `${BASE_REL}/schedules/schedules.csv`,
+    `${RAW_MAIN}/data/games.csv`,
+    `${RAW_MAST}/data/games.csv`
   ];
-  const txt = await tryFirst(CANDIDATES);
-  if (!txt) throw new Error("Could not load schedules (games.csv) from nflverse mirrors");
+  const txt = await tryFirst(C);
+  if (!txt) throw new Error("Could not load schedules");
   return parseCsvLoose(txt);
 }
 
-// Team weekly summary stats (primary features) — use Releases first
+// Team weekly summary stats (PRIMARY, must exist)
 export async function loadTeamWeekly(season) {
-  const s = Number(season || currentYear());
-  const CANDIDATES = [
-    // Releases (preferred)
-    `https://github.com/nflverse/nflverse-data/releases/download/stats_team/stats_team_week_${s}.csv`,
-    // Raw repo fallbacks (older mirrors)
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/team_week_stats/stats_team_week_${s}.csv`,
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/team_week_stats/stats_team_week_${s}.csv`,
-    `https://raw.githubusercontent.com/nflverse/nflfastR-data/master/team_stats/team_stats_${s}.csv`
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/stats_team/stats_team_week_${y}.csv`,
+    `${RAW_MAIN}/data/team_week_stats/stats_team_week_${y}.csv`,
+    `${RAW_MAST}/data/team_week_stats/stats_team_week_${y}.csv`,
+    // legacy fallback
+    `https://raw.githubusercontent.com/nflverse/nflfastR-data/master/team_stats/team_stats_${y}.csv`
   ];
-  const txt = await tryFirst(CANDIDATES);
-  if (!txt) throw new Error(`Could not load team weekly stats for ${s}`);
+  const txt = await tryFirst(C);
+  if (!txt) throw new Error(`Could not load team weekly for ${y}`);
   return parseCsvLoose(txt);
 }
 
-// Player weekly summary stats (optional enrichments) — Releases first
+// Player weekly summary stats (optional)
 export async function loadPlayerWeekly(season) {
-  const s = Number(season || currentYear());
-  const CANDIDATES = [
-    `https://github.com/nflverse/nflverse-data/releases/download/stats_player/stats_player_week_${s}.csv`,
-    // older/alternate mirrors
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/player_stats/player_stats_${s}.csv`,
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/player_stats/player_stats_${s}.csv`
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/stats_player/stats_player_week_${y}.csv`,
+    `${RAW_MAIN}/data/player_stats/player_stats_${y}.csv`,
+    `${RAW_MAST}/data/player_stats/player_stats_${y}.csv`
   ];
-  const txt = await tryFirst(CANDIDATES);
-  if (!txt) {
-    log("warn", `loadPlayerWeekly(${s}) → [] (no asset yet)`);
-    return [];
-  }
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadPlayerWeekly(${y}) → []`); return []; }
   return parseCsvLoose(txt);
 }
 
-// Team-game advanced (optional; varies by year) — keep tolerant
-export async function loadTeamGameAdvanced(season) {
-  const s = Number(season || currentYear());
-  const CANDIDATES = [
-    // If nflverse later publishes as a release, add here:
-    // `https://github.com/nflverse/nflverse-data/releases/download/team_game/team_game_${s}.csv`,
-    // Raw mirrors commonly seen:
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/team_game/team_game_${s}.csv`,
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/team_game/team_games_${s}.csv`,
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/team_game/team_game_${s}.csv`,
-    `https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/team_game/team_games_${s}.csv`
+// Weekly rosters (optional; helps identify starters)
+export async function loadRostersWeekly(season) {
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/weekly_rosters/weekly_rosters_${y}.csv`,
+    `${RAW_MAIN}/data/rosters/weekly_rosters_${y}.csv`,
+    `${RAW_MAST}/data/rosters/weekly_rosters_${y}.csv`
   ];
-  const txt = await tryFirst(CANDIDATES);
-  if (!txt) {
-    log("warn", `loadTeamGameAdvanced(${s}) → []`);
-    return [];
-  }
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadRostersWeekly(${y}) → []`); return []; }
   return parseCsvLoose(txt);
 }
 
-// Play-by-play CSV (optional: used only if you plan to parse aggregate features)
+// Depth charts (optional; starter flags)
+export async function loadDepthCharts(season) {
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/depth_charts/depth_charts_${y}.csv`,
+    `${RAW_MAIN}/data/depth_charts/depth_charts_${y}.csv`,
+    `${RAW_MAST}/data/depth_charts/depth_charts_${y}.csv`
+  ];
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadDepthCharts(${y}) → []`); return []; }
+  return parseCsvLoose(txt);
+}
+
+// Injuries (optional; weekly reports)
+export async function loadInjuries(season) {
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/injuries/injuries_${y}.csv`,
+    `${RAW_MAIN}/data/injuries/injuries_${y}.csv`,
+    `${RAW_MAST}/data/injuries/injuries_${y}.csv`
+  ];
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadInjuries(${y}) → []`); return []; }
+  return parseCsvLoose(txt);
+}
+
+// Snap counts (optional)
+export async function loadSnapCounts(season) {
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/snap_counts/snap_counts_${y}.csv`,
+    `${RAW_MAIN}/data/snap_counts/snap_counts_${y}.csv`,
+    `${RAW_MAST}/data/snap_counts/snap_counts_${y}.csv`
+  ];
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadSnapCounts(${y}) → []`); return []; }
+  return parseCsvLoose(txt);
+}
+
+// Officials (optional; all-years)
+export async function loadOfficials() {
+  const C = [
+    `${BASE_REL}/officials/officials.csv`,
+    `${RAW_MAIN}/data/officials/officials.csv`,
+    `${RAW_MAST}/data/officials/officials.csv`
+  ];
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", "loadOfficials() → []"); return []; }
+  return parseCsvLoose(txt);
+}
+
+// PFR advanced team stats (optional)
+export async function loadPFRAdvTeam(season) {
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/pfr_advstats/pfr_advstats_team_${y}.csv`,
+    `${RAW_MAIN}/data/pfr_advstats/pfr_advstats_team_${y}.csv`,
+    `${RAW_MAST}/data/pfr_advstats/pfr_advstats_team_${y}.csv`
+  ];
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadPFRAdvTeam(${y}) → []`); return []; }
+  return parseCsvLoose(txt);
+}
+
+// ESPN QBR (optional)
+export async function loadESPNQBR(season) {
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/espn_data/espn_qbr_${y}.csv`,
+    `${RAW_MAIN}/data/espn_qbr/espn_qbr_${y}.csv`,
+    `${RAW_MAST}/data/espn_qbr/espn_qbr_${y}.csv`
+  ];
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadESPNQBR(${y}) → []`); return []; }
+  return parseCsvLoose(txt);
+}
+
+// Play-by-play CSV.GZ (optional; heavy)
 export async function loadPBP(season) {
-  const s = Number(season || currentYear());
-  const CANDIDATES = [
-    `https://github.com/nflverse/nflverse-data/releases/download/pbp/play_by_play_${s}.csv.gz`
+  const y = Number(season || yearNow());
+  const C = [
+    `${BASE_REL}/pbp/play_by_play_${y}.csv.gz`
   ];
-  const txt = await tryFirst(CANDIDATES);
-  if (!txt) {
-    log("warn", `loadPBP(${s}) → []`);
-    return [];
-  }
-  // We’re returning raw CSV text right now; add a gzip step if needed.
+  const buf = await tryFirst(C, true);
+  if (!buf) { log("warn", `loadPBP(${y}) → []`); return []; }
+  let csv;
+  try { csv = gunzipSync(buf).toString("utf8"); }
+  catch { log("warn", "gunzip failed for PBP"); return []; }
+  return parseCsvLoose(csv);
+}
+
+// Team game advanced stats (optional legacy helper)
+export async function loadTeamGameAdvanced(season) {
+  const y = Number(season || yearNow());
+  const C = [
+    `${RAW_MAIN}/data/team_game/team_game_${y}.csv`,
+    `${RAW_MAIN}/data/team_game/team_games_${y}.csv`,
+    `${RAW_MAST}/data/team_game/team_game_${y}.csv`,
+    `${RAW_MAST}/data/team_game/team_games_${y}.csv`
+  ];
+  const txt = await tryFirst(C);
+  if (!txt) { log("warn", `loadTeamGameAdvanced(${y}) → []`); return []; }
   return parseCsvLoose(txt);
 }

--- a/trainer/eloLoader.js
+++ b/trainer/eloLoader.js
@@ -1,0 +1,32 @@
+// trainer/eloLoader.js
+// Loads Elo-like ratings (diff & spread if present) with safe fallbacks.
+
+import { loadSchedules } from "./dataSources.js"; // not strictly required here
+
+async function fetchText(url) {
+  const res = await fetch(url, { redirect: "follow", headers: { "User-Agent": "nfl-wins/1.0 (+actions)" } });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return await res.text();
+}
+function parseCsvLoose(txt){
+  const lines = txt.trim().split(/\r?\n/); if(!lines.length) return [];
+  const h = lines[0].split(",");
+  return lines.slice(1).map(l=>{
+    const c=l.split(","); const o={};
+    for (let i=0;i<h.length;i++) o[h[i]]=c[i]??"";
+    return o;
+  });
+}
+
+export async function loadElo(season) {
+  const y = Number(season);
+  const C = [
+    `https://raw.githubusercontent.com/nflverse/nflverse-data/main/data/elo/elo_${y}.csv`,
+    `https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/elo/elo_${y}.csv`
+  ];
+  for (const url of C) {
+    try { const txt = await fetchText(url); return parseCsvLoose(txt); }
+    catch {}
+  }
+  return [];
+}

--- a/trainer/explainRubric.js
+++ b/trainer/explainRubric.js
@@ -1,0 +1,106 @@
+// trainer/explainRubric.js
+import fs from "node:fs";
+
+export function computeExplainArtifact({ season, week, predictions, context }) {
+  const byId = new Map(context.map(c => [c.game_id, c]));
+  const thresholds = { elo: 15, spread: 1.5, dYPA: 0.7, dSR: 0.02, dNet: 75, venue_dYPA: 0.5, venue_dSR: 0.03, grass_bad_net: -100 };
+  const weights    = { elo: 2.0, market: 1.5, qb_ypa: 1.5, qb_sack: 1.0, rolling_net: 1.0, injuries: 1.0, venue: 0.5, surface: 0.25 };
+
+  const games = predictions.map(g => {
+    const cx = byId.get(g.game_id) || null;
+    const pick = pickTeam(g);
+    const homePick = (pick === g.home_team);
+
+    const elo = cx?.context?.elo || null;
+    const market = cx?.context?.market || null;
+    const venue = cx?.context?.venue || {};
+    const inj = cx?.context?.injuries || {};
+    const qbH = cx?.context?.qb_form?.home || {};
+    const qbA = cx?.context?.qb_form?.away || {};
+    const rollH = cx?.context?.rolling_strength?.home || {};
+    const rollA = cx?.context?.rolling_strength?.away || {};
+
+    const pickSign = homePick ? +1 : -1;
+    const dYPA = (homePick ? 1 : -1) * ((qbH.ypa_3g ?? 0) - (qbA.ypa_3g ?? 0));
+    const dSR  = (homePick ? 1 : -1) * ((qbH.sack_rate_3g ?? 0) - (qbA.sack_rate_3g ?? 0));
+    const dNet = (homePick ? 1 : -1) * ((rollH.net_yds_3g ?? 0) - (rollA.net_yds_3g ?? 0));
+
+    const factors = [];
+    let score = 0;
+    const add = (name, vote, weight, reason) => { const v=Math.max(-1,Math.min(1,vote)); score += v*weight; factors.push({name, vote:v, weight, reason}); };
+    const voteThr = (x, thrPos, thrNeg=undefined) => { const thr = thrNeg==null?thrPos:thrNeg; return x>=thrPos?+1:x<=-thr?-1:0; };
+
+    if (elo) {
+      const diffForPick = pickSign * (elo.diff ?? 0);
+      add("elo", voteThr(diffForPick, thresholds.elo), weights.elo, `Elo ${diffForPick>=0?"+":""}${Math.round(diffForPick)} for ${pick}`);
+    }
+    if (market && Number.isFinite(market.spread_home)) {
+      const favoredHome = market.spread_home < 0;
+      const pickFavored = favoredHome === homePick;
+      const mag = Math.abs(market.spread_home);
+      const v = mag >= thresholds.spread ? (pickFavored ? +1 : -1) : 0;
+      add("market", v, weights.market, pickFavored ? `Market favors ${pick} by ${mag}` : `Market favors opponent by ${mag}`);
+    }
+    add("qb_ypa", voteThr(dYPA, thresholds.dYPA), weights.qb_ypa, `ΔYPA ${dYPA>=0?"+":""}${dYPA.toFixed(2)} last 3`);
+    add("qb_sack", dSR<=-thresholds.dSR?+1:(dSR>=thresholds.dSR?-1:0), weights.qb_sack, `ΔSR ${dSR>=0?"+":""}${dSR.toFixed(3)} (lower better)`);
+    add("rolling_net", voteThr(dNet, thresholds.dNet), weights.rolling_net, `ΔNet ${dNet>=0?"+":""}${Math.round(dNet)} over 3g`);
+
+    const starOutPick = (homePick ? inj.home_out : inj.away_out) || [];
+    const starOutOpp  = (!homePick ? inj.home_out : inj.away_out) || [];
+    const starPickQB = starOutPick.some(p => (p.star || p.pos === "QB"));
+    const starOppQB  = starOutOpp.some(p => (p.star || p.pos === "QB"));
+    let injVote = 0;
+    if (starOppQB) injVote += +2;
+    if (starPickQB) injVote += -2;
+    const nonQBStars = ["RB","WR","TE","CB","S","EDGE","LB","DL"];
+    const countStars = (arr) => arr.filter(p => p.pos === "QB" ? false : (p.star || nonQBStars.includes(p.pos))).length;
+    injVote += Math.min(2, countStars(starOutOpp));
+    injVote -= Math.min(2, countStars(starOutPick));
+    if (injVote !== 0) add("injuries", Math.sign(injVote), weights.injuries, `star injuries net ${injVote>0?"favor":"hurt"} ${pick}`);
+
+    if (venue?.is_dome) {
+      const v = dYPA >= thresholds.venue_dYPA ? +1 : 0;
+      add("venue", v, weights.venue, v ? "Dome + better YPA" : "Dome neutral");
+    } else if (venue?.is_outdoor) {
+      const v = dSR >= thresholds.venue_dSR ? -1 : 0;
+      add("venue", v, weights.venue, v ? "Outdoor + worse sack rate" : "Outdoor neutral");
+    }
+    if (venue?.surface === "turf") {
+      const v = dYPA >= thresholds.venue_dYPA ? +1 : 0;
+      add("surface", v, weights.surface, v ? "Turf + better YPA" : "Turf neutral");
+    } else if (venue?.surface === "grass") {
+      const v = dNet <= thresholds.grass_bad_net ? -1 : 0;
+      add("surface", v, weights.surface, v ? "Grass + worse recent net yards" : "Grass neutral");
+    }
+
+    return {
+      game_id: g.game_id,
+      home_team: g.home_team,
+      away_team: g.away_team,
+      pick,
+      blended: g?.probs?.blended ?? null,
+      support_score: Math.round(score * 100) / 100,
+      factors
+    };
+  });
+
+  return {
+    season, week,
+    rubric_version: "1.0.0",
+    thresholds, weights,
+    games
+  };
+}
+
+export async function writeExplainArtifact({ season, week, predictions, context }) {
+  const out = computeExplainArtifact({ season, week, predictions, context });
+  const name = `artifacts/explain_${season}_W${String(week).padStart(2,"0")}.json`;
+  await fs.promises.writeFile(name, JSON.stringify(out, null, 2));
+  return name;
+}
+
+function pickTeam(g) {
+  const p = g?.probs?.blended;
+  if (typeof p === "number") return p >= 0.5 ? g.home_team : g.away_team;
+  return g.home_team;
+}

--- a/trainer/tests/smoke.js
+++ b/trainer/tests/smoke.js
@@ -106,7 +106,8 @@ async function main() {
   if (!result.diagnostics?.metrics?.ensemble) throw new Error("Smoke test: diagnostics missing ensemble metrics");
   if (!Array.isArray(result.btDebug) || !result.btDebug.length) throw new Error("Smoke test: btDebug missing");
 
-  writeArtifacts(result);
+  result.context = [];
+  await writeArtifacts(result);
   updateHistoricalArtifacts({ season, schedules });
 
   const indexPath = `artifacts/season_index_${season}.json`;


### PR DESCRIPTION
## Summary
- fetch nflverse datasets from release-backed sources, add an Elo loader, and build per-game context/explain artifacts during training
- persist weekly context and explanation JSON alongside existing artifacts and expose /context and /explain endpoints in the Worker
- quiet CI logs by setting LOG_LEVEL=warn during the workflow

## Testing
- node trainer/tests/smoke.js

------
https://chatgpt.com/codex/tasks/task_e_68db5c9b0a388330aadb1097359c13ea