### PR TITLE
Improve nflverse ingestion caching and schedule handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,16 @@ Each successful `train:multi` run refreshes or adds:
 | `bt_features_<season>_W<week>.json` | Bradley–Terry feature matrix for audit/backtests.|
 
 ## Data sources
-`trainer/dataSources.js` gracefully falls back across multiple nflverse mirrors/releases for:
-- Schedules/games (`games.csv`)
+`trainer/dataSources.js` now caches downloads per season and gracefully falls back across multiple nflverse mirrors/releases for:
+- Schedules/games (`schedules_<season>.csv` fallback to `games.csv`)
 - Team weekly stats (`stats_team_week_<season>.csv`)
 - Player weekly stats (`stats_player_week_<season>.csv`)
-- Team game advanced stats (`team_game_<season>.csv`)
+- Team game advanced stats (`stats_team_game_<season>.csv`)
 - Play-by-play (`play_by_play_<season>.csv.gz`)
+- Weekly rosters, depth charts, injuries, snap counts, and officials for context packs
+- ESPN Total QBR and Pro-Football-Reference advanced team metrics for quarterback and efficiency context
 
-Set `LOG_LEVEL=debug` to trace which mirrors respond during a run.
+See `docs/data-ingestion.md` for a quick reference to every nflverse dataset we pull and how to extend the loaders. Set `LOG_LEVEL=debug` to trace which mirrors respond during a run.
 
 ## Deployment
 Deploy `api/worker.js` to Cloudflare Workers, editing the `REPO_USER`, `REPO_NAME`, and `BRANCH` constants to point at your fork. The Worker lists the `artifacts/` directory via the GitHub API and serves the newest available predictions when `season` or `week` is omitted, enabling the bundled `openapi.yaml` to power a Custom GPT Action or any HTTP client.

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -1,0 +1,35 @@
+# Data ingestion cheat sheet
+
+This project relies exclusively on [nflverse](https://github.com/nflverse/) public datasets. The `trainer/dataSources.js`
+module wraps every feed with:
+
+- **Redundant mirrors** – GitHub release assets, `main` and `master` branches, and legacy `nfldata` fallbacks.
+- **Automatic gzip handling** – URLs are tried with and without the `.gz` suffix.
+- **Per-season caching** – repeated calls within a single training run reuse in-memory copies so we only download each table once.
+
+Use this table to understand what we load, how often nflverse updates it, and where it is consumed.
+
+| Dataset | Primary URL pattern | Update cadence | Used by |
+| --- | --- | --- | --- |
+| Schedules & scores | `releases/download/schedules/schedules_<season>.csv` → `nfldata/games.csv` | Daily in-season | Feature builders, trainers, context packs |
+| Team weekly stats | `releases/download/stats_team/stats_team_week_<season>.csv` | Weekly | Feature builders (`featureBuild.js`) |
+| Team game advanced stats | `releases/download/stats_team/stats_team_game_<season>.csv` | Weekly | Feature builders (advanced splits) |
+| Player weekly stats | `releases/download/stats_player/stats_player_week_<season>.csv` | Weekly | Player usage + QB form |
+| Play-by-play | `releases/download/pbp/play_by_play_<season>.csv.gz` | Daily/weekly | EPA & success aggregates |
+| Weekly rosters | `releases/download/weekly_rosters/weekly_rosters_<season>.csv` | Daily | Context packs (starters) |
+| Depth charts | `releases/download/depth_charts/depth_charts_<season>.csv` | Daily | Context packs (starter mapping) |
+| Injuries | `releases/download/injuries/injuries_<season>.csv` | Daily (Thu-Sun heavy) | Context packs (injury report summaries) |
+| Snap counts | `releases/download/snap_counts/snap_counts_<season>.csv` | Weekly | Available for usage-based context |
+| ESPN Total QBR | `releases/download/espn_data/espn_qbr_<season>.csv` | Weekly | QB form overlay |
+| PFR advanced team | `releases/download/pfr_advstats/pfr_advstats_team_<season>.csv` | Weekly | Team efficiency context |
+| Officials | `releases/download/officials/officials.csv` | Sporadic | Optional officiating context |
+
+## Extending the loaders
+
+1. Identify the nflverse dataset (check [nflverse-data README](https://github.com/nflverse/nflverse-data)).
+2. Add a loader in `trainer/dataSources.js` following the same pattern: declare mirrors, wrap in `cached(...)`, and export it.
+3. Consume the new data in feature builders or context packs as needed.
+
+Because every loader now caches by `(season, dataset)`, you can safely call them inside loops or Promise.all chains without
+re-downloading. If you need to force a refresh (for example when running long-lived services), clear the corresponding cache
+map before invoking the loader again.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,423 @@
+{
+  "name": "nfl-wins-free-stack",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nfl-wins-free-stack",
+      "version": "1.0.0",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "csv-parse": "^5.5.6",
+        "ml-cart": "^2.0.1",
+        "ml-logistic-regression": "^2.0.0",
+        "ml-matrix": "^6.11.0",
+        "papaparse": "^5.4.1"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-generator-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-generator-function/-/async-generator-function-1.0.0.tgz",
+      "integrity": "sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.0.tgz",
+      "integrity": "sha512-xPypGGincdfyl/AiSGa7GjXLkvld9V7GjZlowup9SHIJnQnHLFiLODCd/DqKOp0PBagbHJ68r1KJI9Mut7m4sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.1.tgz",
+      "integrity": "sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "async-generator-function": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ml-array-max": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
+      "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-mean": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
+      "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-sum": "^1.1.6"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
+      "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
+      "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0",
+        "ml-array-max": "^1.2.4",
+        "ml-array-min": "^1.2.3"
+      }
+    },
+    "node_modules/ml-array-sum": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
+      "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-cart": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ml-cart/-/ml-cart-2.1.1.tgz",
+      "integrity": "sha512-f6rIj4EzbjqKLJa2Qmm5AjZ0WVgk+Y7J1N/+pQVaFr0d4oM1uZPLOh5h665LyH+bLBHTFEbvSR4OLKmJRQ8KfA==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-mean": "^1.1.5",
+        "ml-matrix": "^6.8.2"
+      }
+    },
+    "node_modules/ml-logistic-regression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-logistic-regression/-/ml-logistic-regression-2.0.0.tgz",
+      "integrity": "sha512-xHhB91ut8GRRbJyB1ZQfKsl1MHmE1PqMeRjxhks96M5BGvCbC9eEojf4KgRMKM2LxFblhVUcVzweAoPB48Nt0A==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-matrix": "^6.5.0"
+      }
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.1.tgz",
+      "integrity": "sha512-TJ+8eOFdp+INvzR4zAuwBQJznDUfktMtOB6g/hUcGh3rcyjxbz4Te57Pgri8Q9bhSQ7Zys4IYOGhFdnlgeB6Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.1",
+        "ml-array-rescale": "^1.3.7"
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/scripts/debugData.js
+++ b/scripts/debugData.js
@@ -16,7 +16,7 @@ function counts(arr, key) {
 
 (async () => {
   console.log(`DEBUG: Season=${SEASON}, TargetWeek=${WEEK}`);
-  const schedules = await loadSchedules();
+  const schedules = await loadSchedules(SEASON);
   const schedReg = schedules.filter(r => Number(r.season) === SEASON);
   console.log(`schedules total rows (this season): ${schedReg.length}`);
   console.log(`schedules season_type counts:`, counts(schedReg, "season_type"));

--- a/scripts/resolveWeek.js
+++ b/scripts/resolveWeek.js
@@ -26,7 +26,7 @@ function hasFinalScore(g) {
 
 async function main() {
   const SEASON = Number(process.env.SEASON || new Date().getFullYear());
-  const schedules = await loadSchedules();
+  const schedules = await loadSchedules(SEASON);
 
   const reg = schedules.filter(
     (g) => Number(g.season) === SEASON && isReg(g.season_type)
@@ -47,7 +47,8 @@ async function main() {
   console.log(`Resolved WEEK=${WEEK}`);
 }
 
-main().catch(() => {
+main().catch((err) => {
   // Be tolerant; let the workflow continue even if resolution fails
+  console.warn(`resolveWeek failed: ${err?.message || err}`);
   console.log("Resolved WEEK=");
 });

--- a/trainer/contextPack.js
+++ b/trainer/contextPack.js
@@ -9,7 +9,7 @@ import { loadElo } from "./eloLoader.js";
 
 export async function buildContextForWeek(season, week) {
   const [schedAll, teamW, playersW, rostersW, depthW, injuriesW, pfrTeam, qbr, elo] = await Promise.all([
-    loadSchedules(),
+    loadSchedules(season),
     loadTeamWeekly(season),
     loadPlayerWeekly(season),
     loadRostersWeekly(season),

--- a/trainer/dataSources.js
+++ b/trainer/dataSources.js
@@ -13,6 +13,39 @@ function toInt(x) {
   return Number.isFinite(n) ? Math.trunc(n) : null;
 }
 
+const caches = {
+  schedules: new Map(),
+  teamWeekly: new Map(),
+  teamGame: new Map(),
+  playerWeekly: new Map(),
+  rostersWeekly: new Map(),
+  depthCharts: new Map(),
+  injuries: new Map(),
+  snapCounts: new Map(),
+  officials: new Map(),
+  pfrAdvTeam: new Map(),
+  espnQBR: new Map(),
+  pbp: new Map()
+};
+
+function cached(cache, key, loader) {
+  if (cache.has(key)) {
+    const value = cache.get(key);
+    return value instanceof Promise ? value : Promise.resolve(value);
+  }
+  const promise = loader()
+    .then((result) => {
+      cache.set(key, result);
+      return result;
+    })
+    .catch((err) => {
+      cache.delete(key);
+      throw err;
+    });
+  cache.set(key, promise);
+  return promise;
+}
+
 async function fetchCsvFlexible(url) {
   // Try the exact URL and its .gz or non-gz twin.
   const tryUrls = [url];
@@ -74,268 +107,305 @@ function coerceScheduleRow(r) {
 
 export async function loadSchedules(season) {
   const seasonInt = toInt(season);
-  const rel = [
-    `${BASE_REL}/schedules/schedules.csv`,
-    `${BASE_REL}/schedules/schedules_${seasonInt}.csv`,
-    `${BASE_REL}/schedules/schedules_${seasonInt}.csv.gz`
-  ];
-  const fb = [
-    "https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv"
-  ];
-  const tried = [];
-  for (const u of rel) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      const out = rows.map(coerceScheduleRow).filter(r => r.season === seasonInt);
-      if (out.length) { console.log(`[loadSchedules] OK ${source} (${out.length})`); return out; }
-      tried.push(`${u} (no rows for ${seasonInt})`);
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+  if (seasonInt == null) {
+    throw new Error(`loadSchedules requires a valid season, received ${season}`);
   }
-  for (const u of fb) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      const out = rows.map(coerceScheduleRow).filter(r => r.season === seasonInt);
-      if (out.length) { console.log(`[loadSchedules] OK FB ${source} (${out.length})`); return out; }
-      tried.push(`${u} (no rows for ${seasonInt})`);
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  throw new Error(`Could not load schedules for ${seasonInt}:\n  - ${tried.join("\n  - ")}`);
+  return cached(caches.schedules, seasonInt, async () => {
+    const rel = [
+      `${BASE_REL}/schedules/schedules.csv`,
+      `${BASE_REL}/schedules/schedules_${seasonInt}.csv`,
+      `${BASE_REL}/schedules/schedules_${seasonInt}.csv.gz`
+    ];
+    const fb = [
+      "https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv"
+    ];
+    const tried = [];
+    for (const u of rel) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        const out = rows.map(coerceScheduleRow).filter(r => r.season === seasonInt);
+        if (out.length) { console.log(`[loadSchedules] OK ${source} (${out.length})`); return out; }
+        tried.push(`${u} (no rows for ${seasonInt})`);
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    for (const u of fb) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        const out = rows.map(coerceScheduleRow).filter(r => r.season === seasonInt);
+        if (out.length) { console.log(`[loadSchedules] OK FB ${source} (${out.length})`); return out; }
+        tried.push(`${u} (no rows for ${seasonInt})`);
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    throw new Error(`Could not load schedules for ${seasonInt}:\n  - ${tried.join("\n  - ")}`);
+  });
 }
 
 // ---------- Team weekly ----------
 export async function loadTeamWeekly(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/stats_team/stats_team_week_${y}.csv`,
-    `${RAW_MAIN}/data/team_week_stats/stats_team_week_${y}.csv`,
-    `${RAW_MAST}/data/team_week_stats/stats_team_week_${y}.csv`,
-    `${BASE_REL}/stats_team/stats_team_week_${y}.csv.gz`,
-    `${BASE_REL}/stats_team/stats_team_week.csv`,
-    `${BASE_REL}/stats_team/stats_team_week.csv.gz`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      const filtered = rows.filter(r => toInt(r.season) === y);
-      const out = filtered.length ? filtered : rows;
-      console.log(`[loadTeamWeekly] OK ${source} (rows=${out.length})`);
-      return out;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  throw new Error(`Could not load team weekly stats for ${y}:\n  - ${tried.join("\n  - ")}`);
+  if (y == null) throw new Error(`loadTeamWeekly requires a valid season, received ${season}`);
+  return cached(caches.teamWeekly, y, async () => {
+    const candidates = [
+      `${BASE_REL}/stats_team/stats_team_week_${y}.csv`,
+      `${RAW_MAIN}/data/team_week_stats/stats_team_week_${y}.csv`,
+      `${RAW_MAST}/data/team_week_stats/stats_team_week_${y}.csv`,
+      `${BASE_REL}/stats_team/stats_team_week_${y}.csv.gz`,
+      `${BASE_REL}/stats_team/stats_team_week.csv`,
+      `${BASE_REL}/stats_team/stats_team_week.csv.gz`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        const filtered = rows.filter(r => toInt(r.season) === y);
+        const out = filtered.length ? filtered : rows;
+        console.log(`[loadTeamWeekly] OK ${source} (rows=${out.length})`);
+        return out;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    throw new Error(`Could not load team weekly stats for ${y}:\n  - ${tried.join("\n  - ")}`);
+  });
 }
 
 // ---------- Player weekly (optional) ----------
 export async function loadPlayerWeekly(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/stats_player/stats_player_week_${y}.csv`,
-    `${BASE_REL}/stats_player/stats_player_week_${y}.csv.gz`,
-    `${BASE_REL}/stats_player/stats_player_week.csv`,
-    `${BASE_REL}/stats_player/stats_player_week.csv.gz`,
-    `${RAW_MAIN}/data/player_stats/player_stats_${y}.csv`,
-    `${RAW_MAST}/data/player_stats/player_stats_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      const filtered = rows.filter(r => toInt(r.season) === y);
-      const out = filtered.length ? filtered : rows;
-      console.log(`[loadPlayerWeekly] OK ${source} (rows=${out.length})`);
-      return out;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadPlayerWeekly] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadPlayerWeekly requires a valid season, received ${season}`);
+  return cached(caches.playerWeekly, y, async () => {
+    const candidates = [
+      `${BASE_REL}/stats_player/stats_player_week_${y}.csv`,
+      `${BASE_REL}/stats_player/stats_player_week_${y}.csv.gz`,
+      `${BASE_REL}/stats_player/stats_player_week.csv`,
+      `${BASE_REL}/stats_player/stats_player_week.csv.gz`,
+      `${RAW_MAIN}/data/player_stats/player_stats_${y}.csv`,
+      `${RAW_MAST}/data/player_stats/player_stats_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        const filtered = rows.filter(r => toInt(r.season) === y);
+        const out = filtered.length ? filtered : rows;
+        console.log(`[loadPlayerWeekly] OK ${source} (rows=${out.length})`);
+        return out;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadPlayerWeekly] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- Weekly rosters (optional) ----------
 export async function loadRostersWeekly(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/weekly_rosters/weekly_rosters_${y}.csv`,
-    `${BASE_REL}/weekly_rosters/weekly_rosters_${y}.csv.gz`,
-    `${RAW_MAIN}/data/rosters/weekly_rosters_${y}.csv`,
-    `${RAW_MAST}/data/rosters/weekly_rosters_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadRostersWeekly] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadRostersWeekly] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadRostersWeekly requires a valid season, received ${season}`);
+  return cached(caches.rostersWeekly, y, async () => {
+    const candidates = [
+      `${BASE_REL}/weekly_rosters/weekly_rosters_${y}.csv`,
+      `${BASE_REL}/weekly_rosters/weekly_rosters_${y}.csv.gz`,
+      `${RAW_MAIN}/data/rosters/weekly_rosters_${y}.csv`,
+      `${RAW_MAST}/data/rosters/weekly_rosters_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadRostersWeekly] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadRostersWeekly] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- Depth charts (optional) ----------
 export async function loadDepthCharts(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/depth_charts/depth_charts_${y}.csv`,
-    `${BASE_REL}/depth_charts/depth_charts_${y}.csv.gz`,
-    `${RAW_MAIN}/data/depth_charts/depth_charts_${y}.csv`,
-    `${RAW_MAST}/data/depth_charts/depth_charts_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadDepthCharts] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadDepthCharts] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadDepthCharts requires a valid season, received ${season}`);
+  return cached(caches.depthCharts, y, async () => {
+    const candidates = [
+      `${BASE_REL}/depth_charts/depth_charts_${y}.csv`,
+      `${BASE_REL}/depth_charts/depth_charts_${y}.csv.gz`,
+      `${RAW_MAIN}/data/depth_charts/depth_charts_${y}.csv`,
+      `${RAW_MAST}/data/depth_charts/depth_charts_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadDepthCharts] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadDepthCharts] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- Injuries (optional) ----------
 export async function loadInjuries(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/injuries/injuries_${y}.csv`,
-    `${BASE_REL}/injuries/injuries_${y}.csv.gz`,
-    `${RAW_MAIN}/data/injuries/injuries_${y}.csv`,
-    `${RAW_MAST}/data/injuries/injuries_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadInjuries] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadInjuries] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadInjuries requires a valid season, received ${season}`);
+  return cached(caches.injuries, y, async () => {
+    const candidates = [
+      `${BASE_REL}/injuries/injuries_${y}.csv`,
+      `${BASE_REL}/injuries/injuries_${y}.csv.gz`,
+      `${RAW_MAIN}/data/injuries/injuries_${y}.csv`,
+      `${RAW_MAST}/data/injuries/injuries_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadInjuries] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadInjuries] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- Snap counts (optional) ----------
 export async function loadSnapCounts(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/snap_counts/snap_counts_${y}.csv`,
-    `${BASE_REL}/snap_counts/snap_counts_${y}.csv.gz`,
-    `${RAW_MAIN}/data/snap_counts/snap_counts_${y}.csv`,
-    `${RAW_MAST}/data/snap_counts/snap_counts_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadSnapCounts] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadSnapCounts] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadSnapCounts requires a valid season, received ${season}`);
+  return cached(caches.snapCounts, y, async () => {
+    const candidates = [
+      `${BASE_REL}/snap_counts/snap_counts_${y}.csv`,
+      `${BASE_REL}/snap_counts/snap_counts_${y}.csv.gz`,
+      `${RAW_MAIN}/data/snap_counts/snap_counts_${y}.csv`,
+      `${RAW_MAST}/data/snap_counts/snap_counts_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadSnapCounts] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadSnapCounts] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- Officials (optional, all-years) ----------
 export async function loadOfficials() {
-  const candidates = [
-    `${BASE_REL}/officials/officials.csv`,
-    `${BASE_REL}/officials/officials.csv.gz`,
-    `${RAW_MAIN}/data/officials/officials.csv`,
-    `${RAW_MAST}/data/officials/officials.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadOfficials] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadOfficials] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  return cached(caches.officials, "all", async () => {
+    const candidates = [
+      `${BASE_REL}/officials/officials.csv`,
+      `${BASE_REL}/officials/officials.csv.gz`,
+      `${RAW_MAIN}/data/officials/officials.csv`,
+      `${RAW_MAST}/data/officials/officials.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadOfficials] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadOfficials] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- PFR advanced team (optional) ----------
 export async function loadPFRAdvTeam(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/pfr_advstats/pfr_advstats_team_${y}.csv`,
-    `${BASE_REL}/pfr_advstats/pfr_advstats_team_${y}.csv.gz`,
-    `${RAW_MAIN}/data/pfr_advstats/pfr_advstats_team_${y}.csv`,
-    `${RAW_MAST}/data/pfr_advstats/pfr_advstats_team_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadPFRAdvTeam] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadPFRAdvTeam] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadPFRAdvTeam requires a valid season, received ${season}`);
+  return cached(caches.pfrAdvTeam, y, async () => {
+    const candidates = [
+      `${BASE_REL}/pfr_advstats/pfr_advstats_team_${y}.csv`,
+      `${BASE_REL}/pfr_advstats/pfr_advstats_team_${y}.csv.gz`,
+      `${RAW_MAIN}/data/pfr_advstats/pfr_advstats_team_${y}.csv`,
+      `${RAW_MAST}/data/pfr_advstats/pfr_advstats_team_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadPFRAdvTeam] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadPFRAdvTeam] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- ESPN QBR (optional) ----------
 export async function loadESPNQBR(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/espn_data/espn_qbr_${y}.csv`,
-    `${BASE_REL}/espn_data/espn_qbr_${y}.csv.gz`,
-    `${RAW_MAIN}/data/espn_qbr/espn_qbr_${y}.csv`,
-    `${RAW_MAST}/data/espn_qbr/espn_qbr_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadESPNQBR] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadESPNQBR] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadESPNQBR requires a valid season, received ${season}`);
+  return cached(caches.espnQBR, y, async () => {
+    const candidates = [
+      `${BASE_REL}/espn_data/espn_qbr_${y}.csv`,
+      `${BASE_REL}/espn_data/espn_qbr_${y}.csv.gz`,
+      `${RAW_MAIN}/data/espn_qbr/espn_qbr_${y}.csv`,
+      `${RAW_MAST}/data/espn_qbr/espn_qbr_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadESPNQBR] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadESPNQBR] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- Play-by-play (optional, heavy) ----------
 export async function loadPBP(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/pbp/play_by_play_${y}.csv.gz`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      console.log(`[loadPBP] OK ${source} (rows=${rows.length})`);
-      return rows;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadPBP] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadPBP requires a valid season, received ${season}`);
+  return cached(caches.pbp, y, async () => {
+    const candidates = [
+      `${BASE_REL}/pbp/play_by_play_${y}.csv.gz`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        console.log(`[loadPBP] OK ${source} (rows=${rows.length})`);
+        return rows;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadPBP] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }
 
 // ---------- Team per-game advanced (optional convenience) ----------
 export async function loadTeamGameAdvanced(season) {
   const y = toInt(season);
-  const candidates = [
-    `${BASE_REL}/stats_team/stats_team_game_${y}.csv`,
-    `${BASE_REL}/stats_team/stats_team_game_${y}.csv.gz`,
-    `${BASE_REL}/stats_team/stats_team_game.csv`,
-    `${BASE_REL}/stats_team/stats_team_game.csv.gz`,
-    `${RAW_MAIN}/data/team_game_stats/stats_team_game_${y}.csv`,
-    `${RAW_MAST}/data/team_game_stats/stats_team_game_${y}.csv`
-  ];
-  const tried = [];
-  for (const u of candidates) {
-    try {
-      const { rows, source } = await fetchCsvFlexible(u);
-      const filtered = rows.filter(r => toInt(r.season) === y);
-      const out = filtered.length ? filtered : rows;
-      console.log(`[loadTeamGameAdvanced] OK ${source} (rows=${out.length})`);
-      return out;
-    } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-  }
-  console.warn(`[loadTeamGameAdvanced] empty; tried:\n  - ${tried.join("\n  - ")}`);
-  return [];
+  if (y == null) throw new Error(`loadTeamGameAdvanced requires a valid season, received ${season}`);
+  return cached(caches.teamGame, y, async () => {
+    const candidates = [
+      `${BASE_REL}/stats_team/stats_team_game_${y}.csv`,
+      `${BASE_REL}/stats_team/stats_team_game_${y}.csv.gz`,
+      `${BASE_REL}/stats_team/stats_team_game.csv`,
+      `${BASE_REL}/stats_team/stats_team_game.csv.gz`,
+      `${RAW_MAIN}/data/team_game_stats/stats_team_game_${y}.csv`,
+      `${RAW_MAST}/data/team_game_stats/stats_team_game_${y}.csv`
+    ];
+    const tried = [];
+    for (const u of candidates) {
+      try {
+        const { rows, source } = await fetchCsvFlexible(u);
+        const filtered = rows.filter(r => toInt(r.season) === y);
+        const out = filtered.length ? filtered : rows;
+        console.log(`[loadTeamGameAdvanced] OK ${source} (rows=${out.length})`);
+        return out;
+      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
+    }
+    console.warn(`[loadTeamGameAdvanced] empty; tried:\n  - ${tried.join("\n  - ")}`);
+    return [];
+  });
 }

--- a/trainer/tests/backtest.js
+++ b/trainer/tests/backtest.js
@@ -35,7 +35,7 @@ function regression(points) {
 
 async function main() {
   const season = Number(process.env.SEASON ?? new Date().getFullYear());
-  const schedules = await loadSchedules();
+  const schedules = await loadSchedules(season);
   const teamWeekly = await loadTeamWeekly(season);
   let prev = [];
   try {

--- a/trainer/train.js
+++ b/trainer/train.js
@@ -56,7 +56,7 @@ function round3(x){ return Math.round(Number(x)*1000)/1000; }
 (async function main(){
   console.log(`Training season ${TARGET_SEASON}, week ${TARGET_WEEK}`);
 
-  const schedules = await loadSchedules();
+  const schedules = await loadSchedules(TARGET_SEASON);
   const teamWeekly = await loadTeamWeekly(TARGET_SEASON);
   let teamGame = [];
   try { teamGame = await loadTeamGameAdvanced(TARGET_SEASON); } catch (_) {}

--- a/trainer/train_multi.js
+++ b/trainer/train_multi.js
@@ -7,7 +7,14 @@ import {
   loadTeamWeekly,
   loadTeamGameAdvanced,
   loadPBP,
-  loadPlayerWeekly
+  loadPlayerWeekly,
+  loadRostersWeekly,
+  loadDepthCharts,
+  loadInjuries,
+  loadSnapCounts,
+  loadPFRAdvTeam,
+  loadESPNQBR,
+  loadOfficials
 } from "./dataSources.js";
 import { buildContextForWeek } from "./contextPack.js";
 import { writeExplainArtifact } from "./explainRubric.js";
@@ -482,7 +489,7 @@ export async function runTraining({ season, week, data = {}, options = {} } = {}
   let resolvedWeek = Number(week ?? process.env.WEEK ?? 6);
   if (!Number.isFinite(resolvedWeek)) resolvedWeek = 6;
 
-  const schedules = data.schedules ?? (await loadSchedules());
+  const schedules = data.schedules ?? (await loadSchedules(resolvedSeason));
   const teamWeekly = data.teamWeekly ?? (await loadTeamWeekly(resolvedSeason));
   let teamGame;
   if (data.teamGame !== undefined) {
@@ -1219,7 +1226,7 @@ export function updateHistoricalArtifacts({ season, schedules }) {
 }
 
 async function loadSeasonData(season) {
-  const schedules = await loadSchedules();
+  const schedules = await loadSchedules(season);
   const teamWeekly = await loadTeamWeekly(season);
 
   let teamGame;
@@ -1250,7 +1257,70 @@ async function loadSeasonData(season) {
     playerWeekly = [];
   }
 
-  return { schedules, teamWeekly, teamGame, prevTeamWeekly, pbp, playerWeekly };
+  let rosters;
+  try {
+    rosters = await loadRostersWeekly(season);
+  } catch (err) {
+    rosters = [];
+  }
+
+  let depthCharts;
+  try {
+    depthCharts = await loadDepthCharts(season);
+  } catch (err) {
+    depthCharts = [];
+  }
+
+  let injuries;
+  try {
+    injuries = await loadInjuries(season);
+  } catch (err) {
+    injuries = [];
+  }
+
+  let snapCounts;
+  try {
+    snapCounts = await loadSnapCounts(season);
+  } catch (err) {
+    snapCounts = [];
+  }
+
+  let pfrAdv;
+  try {
+    pfrAdv = await loadPFRAdvTeam(season);
+  } catch (err) {
+    pfrAdv = [];
+  }
+
+  let qbr;
+  try {
+    qbr = await loadESPNQBR(season);
+  } catch (err) {
+    qbr = [];
+  }
+
+  let officials;
+  try {
+    officials = await loadOfficials();
+  } catch (err) {
+    officials = [];
+  }
+
+  return {
+    schedules,
+    teamWeekly,
+    teamGame,
+    prevTeamWeekly,
+    pbp,
+    playerWeekly,
+    rosters,
+    depthCharts,
+    injuries,
+    snapCounts,
+    pfrAdv,
+    qbr,
+    officials
+  };
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- add in-memory caching and stricter season validation to every nflverse data loader
- ensure all training, context, and utility scripts request schedules for the active season and surface richer shared season data
- document the expanded data ingestion pipeline and update resolveWeek logging for easier CI debugging

## Testing
- `SEASON=2023 node scripts/resolveWeek.js` *(fails: network access to nflverse blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db66dd4b6c8330a7093c711211a17e