### PR TITLE
feat: integrate nflverse data facade and advanced weekly diffs

### DIFF
--- a/trainer/dataSources.js
+++ b/trainer/dataSources.js
@@ -1,411 +1,213 @@
 // trainer/dataSources.js
-// Robust nflverse loaders with multi-URL fallbacks (.csv and .csv.gz) and helpful logging.
-// Requires: axios, csv-parse
+import { parse } from 'csv-parse/sync';
+import zlib from 'node:zlib';
 
-import axios from "axios";
-import zlib from "zlib";
-import { parse } from "csv-parse/sync";
-
-// ---------- helpers ----------
-function toInt(x) {
-  if (x === null || x === undefined || x === "") return null;
-  const n = Number(x);
-  return Number.isFinite(n) ? Math.trunc(n) : null;
-}
-
-const caches = {
-  schedules: new Map(),
-  teamWeekly: new Map(),
-  teamGame: new Map(),
-  playerWeekly: new Map(),
-  rostersWeekly: new Map(),
-  depthCharts: new Map(),
-  injuries: new Map(),
-  snapCounts: new Map(),
-  officials: new Map(),
-  pfrAdvTeam: new Map(),
-  espnQBR: new Map(),
-  pbp: new Map()
+// ---------- URLs (exact nflverse sources) ----------
+const REL = {
+  qbr:        ()  => `https://github.com/nflverse/nflverse-data/releases/download/espn_data/qbr_week_level.csv`,
+  officials:  ()  => `https://github.com/nflverse/nflverse-data/releases/download/officials/officials.csv`,
+  schedules:  ()  => `https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv`,
+  snapCounts: (y) => `https://github.com/nflverse/nflverse-data/releases/download/snap_counts/snap_counts_${y}.csv`,
+  teamWeekly: (y) => `https://github.com/nflverse/nflverse-data/releases/download/stats_team/stats_team_week_${y}.csv`,
+  playerWeekly:(y)=> `https://github.com/nflverse/nflverse-data/releases/download/stats_player/stats_player_week_${y}.csv`,
+  rosterWeekly:(y)=> `https://github.com/nflverse/nflverse-data/releases/download/weekly_rosters/roster_weekly_${y}.csv`,
+  depthCharts:(y) => `https://github.com/nflverse/nflverse-data/releases/download/depth_charts/depth_charts_${y}.csv`,
+  ftnCharts:  (y) => `https://github.com/nflverse/nflverse-data/releases/download/ftn_charting/ftn_charting_${y}.csv`,
+  pbp:        (y) => `https://github.com/nflverse/nflverse-data/releases/download/pbp/play_by_play_${y}.csv.gz`,
+  pfrRush:    (y) => `https://github.com/nflverse/nflverse-data/releases/download/pfr_advstats/advstats_week_rush_${y}.csv`,
+  pfrDef:     (y) => `https://github.com/nflverse/nflverse-data/releases/download/pfr_advstats/advstats_week_def_${y}.csv`,
+  pfrPass:    (y) => `https://github.com/nflverse/nflverse-data/releases/download/pfr_advstats/advstats_week_pass_${y}.csv`,
+  pfrRec:     (y) => `https://github.com/nflverse/nflverse-data/releases/download/pfr_advstats/advstats_week_rec_${y}.csv`,
 };
 
-function cached(cache, key, loader) {
-  if (cache.has(key)) {
-    const value = cache.get(key);
-    return value instanceof Promise ? value : Promise.resolve(value);
+// ---------- helpers/caches ----------
+export function toInt(v){ const n = parseInt(v,10); return Number.isFinite(n) ? n : null; }
+const isGz = (u)=>u.endsWith('.gz');
+
+async function fetchBuffer(url){
+  const res = await fetch(url, { redirect:'follow', headers:{'User-Agent':'nflverse-loader'}});
+  if(!res.ok) throw new Error(`HTTP ${res.status} ${url}`);
+  return Buffer.from(new Uint8Array(await res.arrayBuffer()));
+}
+function gunzipMaybe(buf,url){ return isGz(url) ? zlib.gunzipSync(buf) : buf; }
+export async function fetchCsvFlexible(url){
+  const buf = await fetchBuffer(url);
+  const txt = gunzipMaybe(buf,url).toString('utf8');
+  const rows = parse(txt, { columns:true, skip_empty_lines:true, relax_column_count:true, trim:true });
+  return { rows, source:url };
+}
+
+export const caches = {
+  schedules:   new Map(), // key 0
+  qbr:         new Map(),
+  officials:   new Map(),
+  snapCounts:  new Map(), // key season
+  teamWeekly:  new Map(),
+  playerWeekly:new Map(),
+  rosterWeekly:new Map(),
+  depthCharts: new Map(),
+  ftnCharts:   new Map(),
+  pbp:         new Map(),
+  pfrAdv:      new Map(), // merged weekly map (season)
+};
+
+async function cached(store,key,loader){
+  if(store.has(key)) return store.get(key);
+  const val = await loader();
+  store.set(key,val);
+  return val;
+}
+
+// ---------- canonical loaders (exact paths) ----------
+export async function loadSchedules(){
+  return cached(caches.schedules, 0, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.schedules());
+    console.log(`[loadSchedules] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadESPNQBR(){
+  return cached(caches.qbr, 0, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.qbr());
+    console.log(`[loadESPNQBR] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadOfficials(){
+  return cached(caches.officials, 0, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.officials());
+    console.log(`[loadOfficials] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadSnapCounts(season){
+  const y = toInt(season); if(y==null) throw new Error('loadSnapCounts season');
+  return cached(caches.snapCounts, y, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.snapCounts(y));
+    console.log(`[loadSnapCounts] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadTeamWeekly(season){
+  const y = toInt(season); if(y==null) throw new Error('loadTeamWeekly season');
+  return cached(caches.teamWeekly, y, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.teamWeekly(y));
+    console.log(`[loadTeamWeekly] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+// legacy alias in code -> keep signature
+export async function loadTeamGameAdvanced(season){
+  return loadTeamWeekly(season);
+}
+export async function loadPlayerWeekly(season){
+  const y = toInt(season); if(y==null) throw new Error('loadPlayerWeekly season');
+  return cached(caches.playerWeekly, y, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.playerWeekly(y));
+    console.log(`[loadPlayerWeekly] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadRostersWeekly(season){
+  const y = toInt(season); if(y==null) throw new Error('loadRostersWeekly season');
+  return cached(caches.rosterWeekly, y, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.rosterWeekly(y));
+    console.log(`[loadRostersWeekly] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadDepthCharts(season){
+  const y = toInt(season); if(y==null) throw new Error('loadDepthCharts season');
+  return cached(caches.depthCharts, y, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.depthCharts(y));
+    console.log(`[loadDepthCharts] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadFTNCharts(season){
+  const y = toInt(season); if(y==null) throw new Error('loadFTNCharts season');
+  return cached(caches.ftnCharts, y, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.ftnCharts(y));
+    console.log(`[loadFTNCharts] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+export async function loadPBP(season){
+  const y = toInt(season); if(y==null) throw new Error('loadPBP season');
+  return cached(caches.pbp, y, async()=>{
+    const {rows,source} = await fetchCsvFlexible(REL.pbp(y));
+    console.log(`[loadPBP] OK ${source} rows=${rows.length}`);
+    return rows;
+  });
+}
+
+// ---------- PFR advanced weekly (merge rush/def/pass/rec) ----------
+function toNumOrNull(v){ if(v===''||v==null) return null; const n=Number(v); return Number.isFinite(n)?n:null; }
+function extractKeys(row){
+  const season = toInt(row.season ?? row.yr ?? row.year);
+  const week   = toInt(row.week ?? row.wk);
+  const team   = String(row.team ?? row.team_abbr ?? row.TEAM ?? '').toUpperCase();
+  return { season, week, team };
+}
+function prefixPhase(rows, phase){
+  const out=[];
+  for(const r of rows){
+    const {season,week,team}=extractKeys(r);
+    if(season==null||week==null||!team) continue;
+    const o={season,week,team};
+    for(const [k,v] of Object.entries(r)){
+      const lk = k.toLowerCase();
+      if(['season','yr','year','week','wk','team','team_abbr','team_name'].includes(lk)) continue;
+      const n=toNumOrNull(v); if(n==null) continue;
+      o[`${phase}_${lk}`]=n;
+    }
+    out.push(o);
   }
-  const promise = loader()
-    .then((result) => {
-      cache.set(key, result);
-      return result;
-    })
-    .catch((err) => {
-      cache.delete(key);
-      throw err;
-    });
-  cache.set(key, promise);
-  return promise;
+  return out;
 }
-
-async function fetchCsvFlexible(url) {
-  // Try the exact URL and its .gz or non-gz twin.
-  const tryUrls = [url];
-  if (url.endsWith(".gz")) tryUrls.push(url.slice(0, -3));
-  else tryUrls.push(url + ".gz");
-
-  const errs = [];
-  for (const u of tryUrls) {
-    try {
-      const resp = await axios.get(u, {
-        responseType: "arraybuffer",
-        timeout: 30000,
-        headers: {
-          "User-Agent": "nfl-wins-free-stack/1.0",
-          "Accept": "text/csv,application/octet-stream,*/*",
-          "Accept-Encoding": "gzip,deflate,br"
-        }
-      });
-      let buf = Buffer.from(resp.data);
-      // if gzipped, try gunzip
-      const looksGz = u.endsWith(".gz") || (buf.length > 2 && buf[0] === 0x1f && buf[1] === 0x8b);
-      if (looksGz) {
-        try { buf = zlib.gunzipSync(buf); } catch {/* fall through */}
-      }
-      const text = buf.toString("utf8");
-      const rows = parse(text, { columns: true, skip_empty_lines: true });
-      return { rows, source: u };
-    } catch (e) {
-      errs.push(`${u}: ${e?.response?.status || e.code || e.message}`);
+function mergeByKey(...arrays){
+  const key = (r)=>`${r.season}|${r.week}|${r.team}`;
+  const map = new Map();
+  for(const arr of arrays){
+    for(const r of arr){
+      const k=key(r);
+      if(!map.has(k)) map.set(k,{season:r.season,week:r.week,team:r.team});
+      Object.assign(map.get(k), r);
     }
   }
-  const err = new Error(`fetchCsvFlexible failed:\n  - ${errs.join("\n  - ")}`);
-  err._attempts = errs;
-  throw err;
+  return map;
 }
-
-// ---------- bases ----------
-const BASE_REL = "https://github.com/nflverse/nflverse-data/releases/download";
-const RAW_MAIN = "https://raw.githubusercontent.com/nflverse/nflverse-data/main";
-const RAW_MAST = "https://raw.githubusercontent.com/nflverse/nflverse-data/master";
-
-// ---------- Schedules ----------
-function coerceScheduleRow(r) {
-  return {
-    season: toInt(r.season ?? r.year ?? r.Season),
-    week: toInt(r.week ?? r.Week),
-    game_id: r.game_id ?? r.gsis ?? r.game_id_pfr ?? null,
-    gameday: r.gameday ?? r.game_date ?? r.gametime ?? null,
-    game_time_utc: r.game_time_utc ?? r.start_time ?? null,
-    home_team: r.home_team ?? r.home ?? r.home_team_abbr ?? r.team_home ?? null,
-    away_team: r.away_team ?? r.away ?? r.away_team_abbr ?? r.team_away ?? null,
-    home_score: toInt(r.home_score ?? r.score_home ?? r.home_points),
-    away_score: toInt(r.away_score ?? r.score_away ?? r.away_points),
-    roof: r.roof ?? r.roof_type ?? null,
-    surface: r.surface ?? r.surface_short ?? null,
-    game_type: r.game_type ?? r.season_type ?? null
-  };
-}
-
-export async function loadSchedules(season) {
-  const seasonInt = toInt(season);
-  if (seasonInt == null) {
-    throw new Error(`loadSchedules requires a valid season, received ${season}`);
-  }
-  return cached(caches.schedules, seasonInt, async () => {
-    const rel = [
-      `${BASE_REL}/schedules/schedules.csv`,
-      `${BASE_REL}/schedules/schedules_${seasonInt}.csv`,
-      `${BASE_REL}/schedules/schedules_${seasonInt}.csv.gz`
-    ];
-    const fb = [
-      "https://raw.githubusercontent.com/nflverse/nfldata/master/data/games.csv"
-    ];
-    const tried = [];
-    for (const u of rel) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        const out = rows.map(coerceScheduleRow).filter(r => r.season === seasonInt);
-        if (out.length) { console.log(`[loadSchedules] OK ${source} (${out.length})`); return out; }
-        tried.push(`${u} (no rows for ${seasonInt})`);
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    for (const u of fb) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        const out = rows.map(coerceScheduleRow).filter(r => r.season === seasonInt);
-        if (out.length) { console.log(`[loadSchedules] OK FB ${source} (${out.length})`); return out; }
-        tried.push(`${u} (no rows for ${seasonInt})`);
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    throw new Error(`Could not load schedules for ${seasonInt}:\n  - ${tried.join("\n  - ")}`);
+export async function loadPFRAdvTeamWeekly(season){
+  const y = toInt(season); if(y==null) throw new Error('loadPFRAdvTeamWeekly season');
+  return cached(caches.pfrAdv, y, async()=>{
+    const [rush,defn,pass,rec] = await Promise.all([
+      fetchCsvFlexible(REL.pfrRush(y)).then(x=>x.rows).catch(()=>[]),
+      fetchCsvFlexible(REL.pfrDef(y)).then(x=>x.rows).catch(()=>[]),
+      fetchCsvFlexible(REL.pfrPass(y)).then(x=>x.rows).catch(()=>[]),
+      fetchCsvFlexible(REL.pfrRec(y)).then(x=>x.rows).catch(()=>[]),
+    ]);
+    const map = mergeByKey(
+      prefixPhase(rush,'rush'),
+      prefixPhase(defn,'def'),
+      prefixPhase(pass,'pass'),
+      prefixPhase(rec,'rec')
+    );
+    console.log(`[loadPFRAdvTeamWeekly] merged=${map.size}`);
+    return map;
   });
 }
-
-// ---------- Team weekly ----------
-export async function loadTeamWeekly(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadTeamWeekly requires a valid season, received ${season}`);
-  return cached(caches.teamWeekly, y, async () => {
-    const candidates = [
-      `${BASE_REL}/stats_team/stats_team_week_${y}.csv`,
-      `${RAW_MAIN}/data/team_week_stats/stats_team_week_${y}.csv`,
-      `${RAW_MAST}/data/team_week_stats/stats_team_week_${y}.csv`,
-      `${BASE_REL}/stats_team/stats_team_week_${y}.csv.gz`,
-      `${BASE_REL}/stats_team/stats_team_week.csv`,
-      `${BASE_REL}/stats_team/stats_team_week.csv.gz`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        const filtered = rows.filter(r => toInt(r.season) === y);
-        const out = filtered.length ? filtered : rows;
-        console.log(`[loadTeamWeekly] OK ${source} (rows=${out.length})`);
-        return out;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    throw new Error(`Could not load team weekly stats for ${y}:\n  - ${tried.join("\n  - ")}`);
-  });
+export async function loadPFRAdvTeamWeeklyArray(season){
+  const m = await loadPFRAdvTeamWeekly(season);
+  return Array.from(m.values());
 }
 
-// ---------- Player weekly (optional) ----------
-export async function loadPlayerWeekly(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadPlayerWeekly requires a valid season, received ${season}`);
-  return cached(caches.playerWeekly, y, async () => {
-    const candidates = [
-      `${BASE_REL}/stats_player/stats_player_week_${y}.csv`,
-      `${BASE_REL}/stats_player/stats_player_week_${y}.csv.gz`,
-      `${BASE_REL}/stats_player/stats_player_week.csv`,
-      `${BASE_REL}/stats_player/stats_player_week.csv.gz`,
-      `${RAW_MAIN}/data/player_stats/player_stats_${y}.csv`,
-      `${RAW_MAST}/data/player_stats/player_stats_${y}.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        const filtered = rows.filter(r => toInt(r.season) === y);
-        const out = filtered.length ? filtered : rows;
-        console.log(`[loadPlayerWeekly] OK ${source} (rows=${out.length})`);
-        return out;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadPlayerWeekly] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
+// ---- compatibility aliases (your code imports these) ----
+export async function loadPFRAdvTeam(season){
+  // Return array for backward compatibility with existing callers
+  return loadPFRAdvTeamWeeklyArray(season);
 }
-
-// ---------- Weekly rosters (optional) ----------
-export async function loadRostersWeekly(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadRostersWeekly requires a valid season, received ${season}`);
-  return cached(caches.rostersWeekly, y, async () => {
-    const candidates = [
-      `${BASE_REL}/weekly_rosters/roster_weekly_${y}.csv`,
-      `${BASE_REL}/weekly_rosters/roster_weekly_${y}.csv.gz`,
-      `${RAW_MAIN}/data/rosters/roster_weekly_${y}.csv`,
-      `${RAW_MAST}/data/rosters/roster_weekly_${y}.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadRostersWeekly] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadRostersWeekly] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- Depth charts (optional) ----------
-export async function loadDepthCharts(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadDepthCharts requires a valid season, received ${season}`);
-  return cached(caches.depthCharts, y, async () => {
-    const candidates = [
-      `${BASE_REL}/depth_charts/depth_charts_${y}.csv`,
-      `${BASE_REL}/depth_charts/depth_charts_${y}.csv.gz`,
-      `${RAW_MAIN}/data/depth_charts/depth_charts_${y}.csv`,
-      `${RAW_MAST}/data/depth_charts/depth_charts_${y}.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadDepthCharts] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadDepthCharts] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- Injuries (optional) ----------
-export async function loadInjuries(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadInjuries requires a valid season, received ${season}`);
-  return cached(caches.injuries, y, async () => {
-    const candidates = [
-      `${BASE_REL}/injuries/injuries_${y}.csv`,
-      `${BASE_REL}/injuries/injuries_${y}.csv.gz`,
-      `${RAW_MAIN}/data/injuries/injuries_${y}.csv`,
-      `${RAW_MAST}/data/injuries/injuries_${y}.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadInjuries] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadInjuries] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- Snap counts (optional) ----------
-export async function loadSnapCounts(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadSnapCounts requires a valid season, received ${season}`);
-  return cached(caches.snapCounts, y, async () => {
-    const candidates = [
-      `${BASE_REL}/snap_counts/snap_counts_${y}.csv`,
-      `${BASE_REL}/snap_counts/snap_counts_${y}.csv.gz`,
-      `${RAW_MAIN}/data/snap_counts/snap_counts_${y}.csv`,
-      `${RAW_MAST}/data/snap_counts/snap_counts_${y}.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadSnapCounts] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadSnapCounts] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- Officials (optional, all-years) ----------
-export async function loadOfficials() {
-  return cached(caches.officials, "all", async () => {
-    const candidates = [
-      `${BASE_REL}/officials/officials.csv`,
-      `${BASE_REL}/officials/officials.csv.gz`,
-      `${RAW_MAIN}/data/officials/officials.csv`,
-      `${RAW_MAST}/data/officials/officials.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadOfficials] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadOfficials] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- PFR advanced team (optional) ----------
-export async function loadPFRAdvTeam(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadPFRAdvTeam requires a valid season, received ${season}`);
-  return cached(caches.pfrAdvTeam, y, async () => {
-    const candidates = [
-      `${BASE_REL}/pfr_advstats/pfr_advstats_team_${y}.csv`,
-      `${BASE_REL}/pfr_advstats/pfr_advstats_team_${y}.csv.gz`,
-      `${RAW_MAIN}/data/pfr_advstats/pfr_advstats_team_${y}.csv`,
-      `${RAW_MAST}/data/pfr_advstats/pfr_advstats_team_${y}.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadPFRAdvTeam] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadPFRAdvTeam] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- ESPN QBR (optional) ----------
-export async function loadESPNQBR(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadESPNQBR requires a valid season, received ${season}`);
-  return cached(caches.espnQBR, y, async () => {
-    const candidates = [
-      `${BASE_REL}/espn_data/qbr_week_level.csv`,
-      `${BASE_REL}/espn_data/eqbr_week_level.csv.gz`,
-      `${RAW_MAIN}/data/espn_qbr/qbr_week_level.csv`,
-      `${RAW_MAST}/data/espn_qbr/qbr_week_level.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadESPNQBR] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadESPNQBR] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- Play-by-play (optional, heavy) ----------
-export async function loadPBP(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadPBP requires a valid season, received ${season}`);
-  return cached(caches.pbp, y, async () => {
-    const candidates = [
-      `${BASE_REL}/pbp/play_by_play_${y}.csv.gz`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        console.log(`[loadPBP] OK ${source} (rows=${rows.length})`);
-        return rows;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadPBP] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
-}
-
-// ---------- Team per-game advanced (optional convenience) ----------
-export async function loadTeamGameAdvanced(season) {
-  const y = toInt(season);
-  if (y == null) throw new Error(`loadTeamGameAdvanced requires a valid season, received ${season}`);
-  return cached(caches.teamGame, y, async () => {
-    const candidates = [
-      `${BASE_REL}/stats_team/stats_team_week_${y}.csv`,
-      `${BASE_REL}/stats_team/stats_team_week_${y}.csv.gz`,
-      `${BASE_REL}/stats_team/stats_team_week.csv`,
-      `${BASE_REL}/stats_team/stats_team_week.csv.gz`,
-      `${RAW_MAIN}/data/team_game_stats/stats_team_week_${y}.csv`,
-      `${RAW_MAST}/data/team_game_stats/stats_team_week_${y}.csv`
-    ];
-    const tried = [];
-    for (const u of candidates) {
-      try {
-        const { rows, source } = await fetchCsvFlexible(u);
-        const filtered = rows.filter(r => toInt(r.season) === y);
-        const out = filtered.length ? filtered : rows;
-        console.log(`[loadTeamGameAdvanced] OK ${source} (rows=${out.length})`);
-        return out;
-      } catch (e) { tried.push(`${u} (${e.message.split("\n")[0]})`); }
-    }
-    console.warn(`[loadTeamGameAdvanced] empty; tried:\n  - ${tried.join("\n  - ")}`);
-    return [];
-  });
+export async function loadInjuries(){
+  // Not available as a single canonical csv in nflverse-data; return empty & log once
+  console.warn('[loadInjuries] returning empty (no canonical weekly injuries csv in nflverse-data)');
+  return [];
 }


### PR DESCRIPTION
## Summary
- replace the data source loader with direct nflverse release URLs and caching helpers
- add a season database facade that merges nflverse datasets and exposes PFR weekly differentials from the shared databases module
- enrich multi-model training features with diff_* stats and dynamically expand the feature list

## Testing
- `npm install`
- `SEASON=2025 WEEK=2 npm run train:multi` *(fails: ENETUNREACH while fetching nflverse sources)*

------
https://chatgpt.com/codex/tasks/task_e_68dc391e45f48330b95028f93bd97870