### PR TITLE
Implement season discovery and ensemble refinements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "train": "node trainer/train.js",
     "train:multi": "node trainer/train_multi.js",
     "build:index": "node scripts/buildIndex.js",
-    "resolve:week": "node scripts/resolveWeek.js"
+    "resolve:week": "node scripts/resolveWeek.js",
+    "test": "node trainer/tests/model_ann.test.js && node trainer/tests/smoke.js"
   },
   "dependencies": {
     "axios": "^1.7.7",

--- a/trainer/model_bt.js
+++ b/trainer/model_bt.js
@@ -63,6 +63,36 @@ const predictLogit = (X, model) => {
 
 const rowsToMatrix = (rows) => rows.map((r) => BT_FEATURES.map((k) => Number(r.features?.[k] ?? 0)));
 
+const num = (value, fallback = 0) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+function descriptorFromContext(context = {}) {
+  return {
+    elo: num(context.elo_pre, 1500),
+    total_yards: num(context.total_yards, 350),
+    penalty_yards: num(context.penalty_yards, 50),
+    turnovers: num(context.turnovers, 1.5),
+    possession_seconds: num(context.possession_seconds, 1800),
+    r_ratio: num(context.r_ratio, 0.5),
+    plays: num(context.offensive_plays, 65)
+  };
+}
+
+function normalizeActual(actual = {}) {
+  const total = num(actual.total_yards);
+  const pass = num(actual.pass_yards);
+  const ratio = total ? pass / total : num(actual.r_ratio, 0.5);
+  return {
+    total_yards: total,
+    penalty_yards: num(actual.penalty_yards),
+    turnovers: num(actual.turnovers),
+    possession_seconds: num(actual.possession_seconds),
+    r_ratio: ratio
+  };
+}
+
 export function trainBTModel(trainRows, { steps, lr, l2 } = {}) {
   const X = rowsToMatrix(trainRows);
   const y = trainRows.map((r) => Number(r.label_win ?? 0));
@@ -81,16 +111,18 @@ function percentile(sorted, pct) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
 }
 
-function sampleRecent(history, k, rng) {
-  if (!history?.length) return null;
-  const pool = history.slice(-Math.min(k, history.length));
+function sampleRecent(historyEntries, k, rng) {
+  if (!historyEntries?.length) return null;
+  const limit = Math.min(historyEntries.length, Math.max(k * 2, k));
+  const pool = historyEntries.slice(-limit);
   if (!pool.length) return null;
   const sample = [];
   for (let i = 0; i < k; i++) {
     const idx = Math.floor(rng() * pool.length);
-    sample.push(pool[idx]);
+    const chosen = pool[idx];
+    if (chosen?.actual) sample.push(chosen.actual);
   }
-  return sample;
+  return sample.length ? sample : null;
 }
 
 function averageStats(samples) {
@@ -130,22 +162,97 @@ function defaultRng(seed = 1234567) {
 function buildHistory(rows) {
   const history = new Map();
   for (const row of rows) {
-    const push = (team, actual) => {
+    const season = Number(row.season);
+    const week = Number(row.week);
+    const push = (team, opponent, location, context, opponentContext, actual) => {
       if (!team || !actual) return;
       const arr = history.get(team) || [];
       arr.push({
-        total_yards: Number(actual.total_yards ?? 0),
-        penalty_yards: Number(actual.penalty_yards ?? 0),
-        turnovers: Number(actual.turnovers ?? 0),
-        possession_seconds: Number(actual.possession_seconds ?? 0),
-        r_ratio: Number(actual.r_ratio ?? 0)
+        season,
+        week,
+        opponent,
+        location,
+        teamDescriptor: descriptorFromContext(context || {}),
+        opponentDescriptor: descriptorFromContext(opponentContext || {}),
+        actual: normalizeActual(actual)
       });
       history.set(team, arr);
     };
-    push(row.home_team, row.home_actual);
-    push(row.away_team, row.away_actual);
+    push(row.home_team, row.away_team, 'home', row.home_context, row.away_context, row.home_actual);
+    push(row.away_team, row.home_team, 'away', row.away_context, row.home_context, row.away_actual);
+  }
+  for (const arr of history.values()) {
+    arr.sort((a, b) => {
+      const s = (a.season ?? 0) - (b.season ?? 0);
+      if (s !== 0) return s;
+      return (a.week ?? 0) - (b.week ?? 0);
+    });
   }
   return history;
+}
+
+function weeksBetween(targetSeason, targetWeek, season, week) {
+  if (!Number.isFinite(targetSeason) || !Number.isFinite(targetWeek)) return 0;
+  if (!Number.isFinite(season) || !Number.isFinite(week)) return 0;
+  const deltaSeasons = targetSeason - season;
+  const deltaWeeks = targetWeek - week;
+  return deltaSeasons * 18 + deltaWeeks;
+}
+
+function similarityWeight(entry, target) {
+  if (!entry || !target) return 0;
+  const dims = [
+    { key: 'elo', scale: 400 },
+    { key: 'total_yards', scale: 150 },
+    { key: 'penalty_yards', scale: 60 },
+    { key: 'turnovers', scale: 2.5 },
+    { key: 'possession_seconds', scale: 600 },
+    { key: 'r_ratio', scale: 0.25 },
+    { key: 'plays', scale: 20 }
+  ];
+  let dist2 = 0;
+  for (const dim of dims) {
+    const a = entry.opponentDescriptor?.[dim.key] ?? 0;
+    const b = target.descriptor?.[dim.key] ?? 0;
+    const diff = (a - b) / dim.scale;
+    dist2 += diff * diff;
+  }
+  if (entry.location !== target.location) {
+    dist2 += 0.5;
+  }
+  const recencyWeeks = weeksBetween(target.season, target.week, entry.season, entry.week);
+  const recency = Math.exp(-Math.max(0, recencyWeeks) / 24);
+  const kernel = Math.exp(-dist2);
+  return kernel * recency;
+}
+
+function weightedSampleEntries(entries, target, k, rng) {
+  if (!entries?.length) return null;
+  const weights = entries.map((entry) => similarityWeight(entry, target));
+  const positive = weights.filter((w) => w > 0);
+  if (!positive.length) return null;
+  const total = weights.reduce((a, b) => a + b, 0);
+  if (!Number.isFinite(total) || total <= 0) return null;
+  const sample = [];
+  for (let i = 0; i < k; i++) {
+    let u = rng() * total;
+    let chosen = entries[entries.length - 1];
+    for (let j = 0; j < entries.length; j++) {
+      u -= weights[j];
+      if (u <= 0) {
+        chosen = entries[j];
+        break;
+      }
+    }
+    if (chosen?.actual) sample.push(chosen.actual);
+  }
+  return sample.length ? sample : null;
+}
+
+function drawHistorySamples(entries, target, block, rng) {
+  const weighted = weightedSampleEntries(entries, target, block, rng);
+  if (weighted && weighted.length) return weighted;
+  return sampleRecent(entries, block, rng);
 }
 
 export function predictBT({
@@ -169,11 +276,23 @@ export function predictBT({
     );
     const hHist = history.get(row.home_team) || [];
     const aHist = history.get(row.away_team) || [];
+    const homeTarget = {
+      descriptor: descriptorFromContext(row.away_context || {}),
+      location: 'home',
+      season: Number(row.season),
+      week: Number(row.week)
+    };
+    const awayTarget = {
+      descriptor: descriptorFromContext(row.home_context || {}),
+      location: 'away',
+      season: Number(row.season),
+      week: Number(row.week)
+    };
     const probs = [];
     const iterations = Math.max(1, Math.round(bootstrap));
     for (let i = 0; i < iterations; i++) {
-      const hSample = sampleRecent(hHist, block, rng);
-      const aSample = sampleRecent(aHist, block, rng);
+      const hSample = drawHistorySamples(hHist, homeTarget, block, rng);
+      const aSample = drawHistorySamples(aHist, awayTarget, block, rng);
       if (!hSample || !aSample) {
         probs.push(baseProb);
         continue;

--- a/trainer/tests/model_ann.test.js
+++ b/trainer/tests/model_ann.test.js
@@ -1,0 +1,61 @@
+import assert from "assert/strict";
+import { trainANNCommittee, predictANNCommittee, splitTrainVal } from "../model_ann.js";
+
+function makeDeterministicRng(seed = 1) {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+function makeDataset() {
+  const X = [];
+  const y = [];
+  for (let i = 0; i < 40; i++) {
+    const a = (i % 10) / 10;
+    const b = ((39 - i) % 10) / 10;
+    const c = (i % 5) / 5;
+    X.push([a, b, c]);
+    y.push(a + c > b ? 1 : 0);
+  }
+  return { X, y };
+}
+
+(function runTests() {
+  const { X, y } = makeDataset();
+
+  const split1 = splitTrainVal(X, y, 0.25, makeDeterministicRng(123));
+  const split2 = splitTrainVal(X, y, 0.25, makeDeterministicRng(456));
+  assert.notDeepEqual(split1.trainIdx, split2.trainIdx, "splitTrainVal should randomize indices with different seeds");
+
+  const split3 = splitTrainVal(X, y, 0.25, makeDeterministicRng(789));
+  const split4 = splitTrainVal(X, y, 0.25, makeDeterministicRng(789));
+  assert.deepEqual(split3.trainIdx, split4.trainIdx, "splitTrainVal should be deterministic for identical RNGs");
+
+  const model = trainANNCommittee(X, y, {
+    seeds: 6,
+    maxEpochs: 20,
+    patience: 4,
+    lr: 5e-3,
+    timeLimitMs: 2000,
+    committeeSize: 2,
+    committees: 2
+  });
+
+  assert(model.committees.length <= 2, "committee count should respect cap");
+  const totalNetworks = model.committees.reduce((sum, committee) => {
+    assert(committee.networks.length <= 2 && committee.networks.length > 0, "committee size cap violated");
+    return sum + committee.networks.length;
+  }, 0);
+  assert.strictEqual(totalNetworks, model.selected.length, "selected metadata should match retained networks");
+  assert(model.validationLosses.length >= model.selected.length, "validation loss tracking should cover all seeds");
+
+  const preds = predictANNCommittee(model, X);
+  assert.strictEqual(preds.length, X.length, "prediction length mismatch");
+  for (const p of preds) {
+    assert(Number.isFinite(p) && p >= 0 && p <= 1, "probability out of range");
+  }
+
+  console.log("model_ann selection tests passed");
+})();

--- a/trainer/tests/smoke.js
+++ b/trainer/tests/smoke.js
@@ -90,7 +90,8 @@ async function main() {
       annMaxEpochs: 50,
       annCvMaxEpochs: 20,
       annCvSeeds: 2,
-      weightStep: 0.1
+      weightStep: 0.1,
+      skipSeasonDB: true
     }
   });
 


### PR DESCRIPTION
## Summary
- add GitHub release manifest discovery to the data source layer and expose a reusable season resolver for CLI consumers
- update the context and training pipelines to honour bounded season lists while aggregating historical rows and writing an index of generated artifacts
- refine Bradley–Terry bootstrapping, restructure ANN committees with selection tests, and document the new configuration and CI coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df153dbbb083309751e39d0c77c2cd