### PR TITLE
Add Tank01 RapidAPI loaders and fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Train, evaluate, and serve NFL win probabilities using only open nflverse data â
    - `SEASON` (defaults to current year)
    - `WEEK` (defaults to 6; the trainer iterates from Week 1 up to this value if historical data exists)
    - `ANN_SEEDS`, `ANN_MAX_EPOCHS`, `BT_B`, etc. to tune ensemble search.
+   - `TANK01_API_KEY` to enable Tank01 RapidAPI mirrors for seasons 2022 and newer.
 3. Run the full ensemble trainer:
    ```bash
    npm run train:multi
@@ -58,6 +59,8 @@ Each successful `train:multi` run refreshes or adds:
 - Play-by-play (`play_by_play_<season>.csv.gz`)
 - Weekly rosters, depth charts, injuries, snap counts, and officials for context packs
 - ESPN Total QBR and Pro-Football-Reference advanced team metrics for quarterback and efficiency context
+
+To layer in the Tank01 RapidAPI feed for seasons 2022 and newer, set `TANK01_API_KEY`. The loaders will prefer Tank01 schedules, team/player stats, rosters, depth charts, injuries, betting odds, and projections when an API key is present, caching the responses and falling back to nflverse automatically if Tank01 is unavailable. Set `USE_TANK01_LOADERS=true` when running the smoke/backtest scripts to exercise the Tank01 mirrors during CI.
 
 See `docs/data-ingestion.md` for a quick reference to every nflverse dataset we pull and how to extend the loaders. Set `LOG_LEVEL=debug` to trace which mirrors respond during a run.
 

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -1,6 +1,6 @@
 # Data ingestion cheat sheet
 
-This project relies exclusively on [nflverse](https://github.com/nflverse/) public datasets. The `trainer/dataSources.js`
+This project relies exclusively on [nflverse](https://github.com/nflverse/) public datasets by default. The `trainer/dataSources.js`
 module wraps every feed with:
 
 - **Redundant mirrors** – GitHub release assets, `main` and `master` branches, and legacy `nfldata` fallbacks.
@@ -8,6 +8,8 @@ module wraps every feed with:
   downloading anything. The manifest results are cached in-process to avoid repeated API calls during long runs.
 - **Automatic gzip handling** – URLs are tried with and without the `.gz` suffix.
 - **Per-season caching** – repeated calls within a single training run reuse in-memory copies so we only download each table once.
+
+If you set `TANK01_API_KEY`, the loaders will prefer Tank01 RapidAPI responses for seasons 2022 and newer (schedules, team/player weekly stats, rosters, depth charts, injuries, betting odds, projections, and play-by-play) before falling back to nflverse mirrors. This keeps the historical nflverse pipeline intact while layering in higher-frequency Tank01 updates when available.
 
 Use this table to understand what we load, how often nflverse updates it, and where it is consumed.
 

--- a/trainer/tank01Client.js
+++ b/trainer/tank01Client.js
@@ -1,0 +1,132 @@
+// trainer/tank01Client.js
+// Shared RapidAPI client for Tank01 endpoints with retry/backoff handling.
+
+const DEFAULT_HOST = "tank01-nfl-live-in-game-real-time-statistics-nfl.p.rapidapi.com";
+const BASE_URL = `https://${DEFAULT_HOST}`;
+const RETRYABLE = new Set([401, 429]);
+const MAX_DELAY_MS = 10000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const coercePath = (path = "") => {
+  if (!path) return "/";
+  if (/^https?:/i.test(path)) return path;
+  return `${BASE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+};
+
+const appendSearchParams = (url, params) => {
+  if (!params || typeof params !== "object") return;
+  for (const [key, value] of Object.entries(params)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (v == null) continue;
+        url.searchParams.append(key, String(v));
+      }
+    } else if (value instanceof Date) {
+      url.searchParams.append(key, value.toISOString());
+    } else if (typeof value === "object") {
+      url.searchParams.append(key, JSON.stringify(value));
+    } else {
+      url.searchParams.append(key, String(value));
+    }
+  }
+};
+
+export const tank01Config = {
+  host: DEFAULT_HOST,
+  minSeason: 2022
+};
+
+export const hasTank01Key = () => Boolean(process.env.TANK01_API_KEY);
+
+export function tank01EnabledForSeason(season) {
+  if (!hasTank01Key()) return false;
+  const num = Number(season);
+  if (!Number.isFinite(num)) return false;
+  if (process.env.TANK01_DISABLE?.toLowerCase() === "true") return false;
+  return num >= tank01Config.minSeason || process.env.TANK01_FORCE?.toLowerCase() === "true";
+}
+
+function parseTankResponse(json) {
+  if (json == null) return null;
+  if (typeof json !== "object") return json;
+  const status = json.statusCode ?? json.status ?? json.code;
+  if (status && status !== 200) {
+    const message = json.message || json.error || json.body?.message || json.body?.error;
+    const err = new Error(`Tank01 API ${status}${message ? `: ${message}` : ""}`);
+    err.status = status;
+    throw err;
+  }
+  if (json.body && typeof json.body === "object") {
+    return json.body;
+  }
+  if (json.data && typeof json.data === "object") {
+    return json.data;
+  }
+  return json;
+}
+
+export async function fetchTank01(path, { params, method = "GET", retries = 3, signal } = {}) {
+  if (!hasTank01Key()) {
+    throw new Error("TANK01_API_KEY is not configured");
+  }
+  const url = new URL(coercePath(path));
+  appendSearchParams(url, params);
+  const headers = {
+    "X-RapidAPI-Key": process.env.TANK01_API_KEY,
+    "X-RapidAPI-Host": tank01Config.host,
+    Accept: "application/json"
+  };
+
+  let attempt = 0;
+  while (true) {
+    const resp = await fetch(url, { method, headers, signal });
+    if (RETRYABLE.has(resp.status) && attempt < retries) {
+      const backoff = Math.min(500 * 2 ** attempt, MAX_DELAY_MS);
+      attempt += 1;
+      await sleep(backoff);
+      continue;
+    }
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      const err = new Error(`Tank01 HTTP ${resp.status}: ${text}`);
+      err.status = resp.status;
+      throw err;
+    }
+    let json;
+    try {
+      json = await resp.json();
+    } catch (err) {
+      throw new Error(`Failed to parse Tank01 response: ${err?.message || err}`);
+    }
+    try {
+      return parseTankResponse(json);
+    } catch (err) {
+      if (RETRYABLE.has(err.status) && attempt < retries) {
+        const backoff = Math.min(500 * 2 ** attempt, MAX_DELAY_MS);
+        attempt += 1;
+        await sleep(backoff);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+export async function fetchTank01List(path, options = {}) {
+  const body = await fetchTank01(path, options);
+  if (!body) return [];
+  if (Array.isArray(body)) return body;
+  if (typeof body !== "object") return [];
+  const arrays = [];
+  for (const value of Object.values(body)) {
+    if (Array.isArray(value)) {
+      arrays.push(...value);
+    }
+  }
+  if (arrays.length) return arrays;
+  return [];
+}
+
+export default fetchTank01;

--- a/trainer/tank01Transforms.js
+++ b/trainer/tank01Transforms.js
@@ -1,0 +1,335 @@
+// trainer/tank01Transforms.js
+// Helpers to map Tank01 API payloads into nflverse-compatible row shapes.
+
+const pick = (row, keys = [], fallback = null) => {
+  if (!row) return fallback;
+  for (const key of keys) {
+    if (row[key] != null && row[key] !== "") return row[key];
+  }
+  return fallback;
+};
+
+const toInt = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? Math.trunc(num) : null;
+};
+
+const toNum = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const toStr = (value) => {
+  if (value == null) return null;
+  const str = String(value).trim();
+  return str.length ? str : null;
+};
+
+const normTeam = (value) => {
+  const str = toStr(value);
+  return str ? str.toUpperCase() : null;
+};
+
+const normPos = (value) => {
+  const str = toStr(value);
+  return str ? str.toUpperCase() : "";
+};
+
+const sumNum = (...values) => {
+  return values.reduce((acc, v) => acc + (Number.isFinite(v) ? v : 0), 0);
+};
+
+const parseIsoDate = (value) => {
+  if (!value) return null;
+  const str = String(value);
+  if (/^\d{4}-\d{2}-\d{2}/.test(str)) return str.slice(0, 10);
+  return str;
+};
+
+function ensureTimeOfPossession(seconds) {
+  if (!Number.isFinite(seconds)) return null;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+}
+
+export function mapTank01Schedule(row = {}, defaults = {}) {
+  const season = toInt(row.season ?? row.seasonYear ?? row.year ?? defaults.season);
+  const week = toInt(row.week ?? row.weekNumber ?? row.week_no ?? defaults.week);
+  const seasonTypeRaw = pick(row, ["seasonType", "season_type", "gameType"], defaults.season_type ?? "REG");
+  const season_type = toStr(seasonTypeRaw)?.toUpperCase() || "REG";
+  const home_team =
+    normTeam(pick(row, ["homeTeamID", "homeTeam", "home_team", "homeTeamAbbr", "homeAbbr", "home"], defaults.home_team)) ||
+    null;
+  const away_team =
+    normTeam(pick(row, ["awayTeamID", "awayTeam", "away_team", "awayTeamAbbr", "awayAbbr", "away"], defaults.away_team)) ||
+    null;
+  if (!home_team || !away_team || season == null || week == null) return null;
+  const game_id =
+    toStr(
+      pick(row, ["gameID", "gameId", "game_id", "id", "nflGameId"], defaults.game_id ?? `${season}-${week}-${home_team}-${away_team}`)
+    ) || `${season}-${String(week).padStart(2, "0")}-${home_team}-${away_team}`;
+  const home_score = toInt(pick(row, ["homeScore", "home_points", "homeScoreTotal", "homePts", "scoreHome"]));
+  const away_score = toInt(pick(row, ["awayScore", "away_points", "awayScoreTotal", "awayPts", "scoreAway"]));
+  const game_date = parseIsoDate(
+    pick(row, ["gameDate", "game_date", "startDate", "date", "gameDateYMD", "gameDay"], defaults.game_date)
+  );
+  const kickoff = pick(row, ["gameTimeEastern", "startTime", "kickoff", "start_time", "startTimeET"], null);
+  const venue = pick(row, ["stadium", "venue", "site", "location"], null);
+  const neutral = pick(row, ["neutralSite", "isNeutralSite", "neutral_field"], null);
+
+  return {
+    season,
+    week,
+    season_type,
+    game_id,
+    game_date,
+    kickoff,
+    venue,
+    neutral_site: neutral === true || String(neutral).toLowerCase() === "true" ? 1 : 0,
+    home_team,
+    away_team,
+    home_score,
+    away_score,
+    result: home_score != null && away_score != null ? home_score - away_score : null
+  };
+}
+
+export function mapTank01TeamWeek(row = {}, defaults = {}) {
+  const season = toInt(row.season ?? row.seasonYear ?? defaults.season);
+  const week = toInt(row.week ?? row.weekNumber ?? row.week_no ?? defaults.week);
+  const team = normTeam(pick(row, ["teamID", "team", "teamAbbr", "recentTeam", "team_code"], defaults.team));
+  const opponent = normTeam(pick(row, ["opponentID", "opponent", "opponentAbbr", "oppAbbr", "opp"], defaults.opponent));
+  if (!team || season == null || week == null) return null;
+
+  const passYds = toNum(
+    pick(row, [
+      "passingYards",
+      "passYards",
+      "pass_yards",
+      "passYds",
+      "offPassYards",
+      "pass_yards_gained",
+      "passingYardsNet"
+    ])
+  );
+  const rushYds = toNum(
+    pick(row, [
+      "rushingYards",
+      "rushYards",
+      "rushing_yards",
+      "rush_yards",
+      "offRushYards",
+      "rushingYardsNet"
+    ])
+  );
+  const penaltyYds = toNum(pick(row, ["penaltyYards", "penaltiesYards", "penalty_yards", "penYds"]));
+  const totalYds = toNum(pick(row, ["totalYards", "yards", "offTotalYards", "total_yards"])) ?? sumNum(passYds, rushYds);
+  const turnovers = toNum(pick(row, ["turnovers", "turnoversTotal", "giveaways", "totalTurnovers"])) ?? null;
+  const interceptions = toNum(pick(row, ["defInterceptions", "interceptions", "interceptionsMade", "def_int"]));
+  const defFum = toNum(pick(row, ["defFumblesRecovered", "fumblesRecovered", "def_fumbles"]));
+  const firstDownPass = toNum(pick(row, ["firstDownPass", "passingFirstDowns", "pass_first_downs"]));
+  const firstDownRush = toNum(pick(row, ["firstDownRush", "rushingFirstDowns", "rush_first_downs"]));
+  const firstDownRec = toNum(pick(row, ["firstDownRec", "receivingFirstDowns", "rec_first_downs"]));
+  const possSeconds = toNum(pick(row, ["timeOfPossessionSeconds", "timeOfPossession", "possessionSeconds", "possession"], 0));
+  const posClock = ensureTimeOfPossession(
+    Number.isFinite(possSeconds) ? possSeconds : toNum(pick(row, ["timeOfPossessionDecimal", "time_of_possession_seconds"]))
+  );
+
+  const wins = toInt(pick(row, ["wins", "teamWins"], null));
+  const losses = toInt(pick(row, ["losses", "teamLosses"], null));
+
+  return {
+    season,
+    week,
+    team,
+    opponent,
+    passing_yards: passYds ?? null,
+    rushing_yards: rushYds ?? null,
+    penalty_yards: penaltyYds ?? null,
+    total_yards: totalYds ?? null,
+    turnovers: turnovers ?? null,
+    def_interceptions: interceptions ?? null,
+    def_fumbles: defFum ?? null,
+    passing_first_downs: firstDownPass ?? null,
+    rushing_first_downs: firstDownRush ?? null,
+    receiving_first_downs: firstDownRec ?? null,
+    time_of_possession: posClock,
+    wins,
+    losses,
+    season_type: toStr(row.seasonType ?? row.season_type ?? defaults.season_type ?? "REG") || "REG"
+  };
+}
+
+export function mapTank01PlayerWeek(row = {}, defaults = {}) {
+  const season = toInt(row.season ?? row.seasonYear ?? defaults.season);
+  const week = toInt(row.week ?? row.weekNumber ?? row.week_no ?? defaults.week);
+  const team = normTeam(pick(row, ["recentTeam", "team", "teamAbbr", "teamID", "team_code"], defaults.team));
+  const opponent = normTeam(pick(row, ["opponent", "oppAbbr", "opponentAbbr"], defaults.opponent));
+  if (season == null || week == null) return null;
+
+  return {
+    season,
+    week,
+    recent_team: team,
+    team,
+    opponent,
+    player_id: pick(row, ["playerID", "playerId", "id"], null),
+    player_display_name: pick(row, ["playerName", "displayName", "name"], null),
+    position: normPos(pick(row, ["position", "pos", "playerPosition"])),
+    rushing_attempts: toNum(pick(row, ["rushingAttempts", "rushAttempts", "rushAtt", "attemptsRush"])),
+    rushing_yards: toNum(pick(row, ["rushingYards", "rushYards", "rushYds"])),
+    rushing_tds: toNum(pick(row, ["rushingTD", "rushingTouchdowns", "rushTD"])),
+    rushing_fumbles_lost: toNum(pick(row, ["fumblesLost", "rushingFumblesLost", "rushFumblesLost"])),
+    receiving_targets: toNum(pick(row, ["targets", "receivingTargets", "recTargets"])),
+    receiving_yards: toNum(pick(row, ["receivingYards", "recYards", "recYds"])),
+    receiving_tds: toNum(pick(row, ["receivingTD", "recTD"])),
+    receiving_fumbles_lost: toNum(pick(row, ["receivingFumblesLost", "recFumblesLost"])),
+    passing_attempts: toNum(pick(row, ["passingAttempts", "passAttempts", "attemptsPass"])),
+    passing_completions: toNum(pick(row, ["passingCompletions", "passCompletions", "completions"])),
+    passing_yards: toNum(pick(row, ["passingYards", "passYards", "passYds"])),
+    passing_tds: toNum(pick(row, ["passingTD", "passTD"])),
+    passing_interceptions: toNum(pick(row, ["interceptions", "passINT"])),
+    air_yards: toNum(pick(row, ["airYards", "passAirYards", "airyards"])),
+    sacks: toNum(pick(row, ["sacks", "sacked", "qbSacked", "sacksTaken"]))
+  };
+}
+
+export function mapTank01Roster(row = {}, defaults = {}) {
+  const team = normTeam(pick(row, ["teamID", "team", "teamAbbr", "recentTeam"], defaults.team));
+  if (!team) return null;
+  return {
+    team,
+    season: toInt(row.season ?? defaults.season),
+    week: toInt(row.week ?? defaults.week),
+    gsis_id: pick(row, ["gsisId", "gsisID", "playerGSIS"], null),
+    status: pick(row, ["status", "rosterStatus", "playerStatus"], null),
+    position: normPos(pick(row, ["position", "pos", "depthChartPosition"])),
+    player_id: pick(row, ["playerID", "playerId", "id"], null),
+    player_display_name: pick(row, ["playerName", "displayName", "name"], null)
+  };
+}
+
+export function mapTank01DepthChart(row = {}, defaults = {}) {
+  const team = normTeam(pick(row, ["teamID", "team", "teamAbbr"], defaults.team));
+  if (!team) return null;
+  return {
+    team,
+    season: toInt(row.season ?? defaults.season),
+    week: toInt(row.week ?? defaults.week),
+    position: normPos(pick(row, ["position", "pos"], "")),
+    depth_order: toInt(pick(row, ["depth", "order", "depthOrder"], null)),
+    player_id: pick(row, ["playerID", "playerId", "id"], null),
+    player_display_name: pick(row, ["playerName", "displayName", "name"], null)
+  };
+}
+
+export function mapTank01Injury(row = {}, defaults = {}) {
+  const team = normTeam(pick(row, ["team", "teamAbbr", "teamID"], defaults.team));
+  if (!team) return null;
+  return {
+    team,
+    season: toInt(row.season ?? defaults.season),
+    week: toInt(row.week ?? defaults.week),
+    player_id: pick(row, ["playerID", "playerId", "id"], null),
+    player_display_name: pick(row, ["playerName", "name", "displayName"], null),
+    position: normPos(pick(row, ["position", "pos"], "")),
+    practice_status: pick(row, ["practiceStatus", "practice", "practice_status"], null),
+    game_status: pick(row, ["gameStatus", "status", "game_status"], null),
+    body_part: pick(row, ["injury", "injuryDetail", "details"], null)
+  };
+}
+
+export function mapTank01Odds(row = {}, defaults = {}) {
+  const season = toInt(row.season ?? defaults.season);
+  const week = toInt(row.week ?? row.weekNumber ?? defaults.week);
+  const home_team = normTeam(pick(row, ["homeTeam", "homeTeamID", "homeAbbr"], defaults.home_team));
+  const away_team = normTeam(pick(row, ["awayTeam", "awayTeamID", "awayAbbr"], defaults.away_team));
+  if (season == null || week == null || !home_team || !away_team) return null;
+  const spread = toNum(pick(row, ["spread", "homeSpread", "spreadCurrent", "line"], null));
+  const total = toNum(pick(row, ["total", "overUnder", "totalPoints"], null));
+  return {
+    season,
+    week,
+    home_team,
+    away_team,
+    spread_line: spread,
+    total_line: total,
+    provider: pick(row, ["provider", "book", "sportsbook", "source"], null),
+    last_update: pick(row, ["lastUpdate", "updated", "timestamp"], null)
+  };
+}
+
+export function mapTank01Projection(row = {}, defaults = {}) {
+  const season = toInt(row.season ?? defaults.season);
+  const week = toInt(row.week ?? defaults.week);
+  if (season == null || week == null) return null;
+  const player_id = pick(row, ["playerID", "playerId", "id"], null);
+  const team = normTeam(pick(row, ["team", "teamAbbr", "teamID"], defaults.team));
+  return {
+    season,
+    week,
+    player_id,
+    player_display_name: pick(row, ["playerName", "displayName", "name"], null),
+    position: normPos(pick(row, ["position", "pos"], "")),
+    team,
+    opponent: normTeam(pick(row, ["opponent", "oppAbbr", "opponentAbbr"], defaults.opponent)),
+    passing_yards: toNum(pick(row, ["passingYards", "passYards", "passYdsProj"])),
+    passing_tds: toNum(pick(row, ["passingTD", "passTDProj"])),
+    rushing_yards: toNum(pick(row, ["rushingYards", "rushYardsProj"])),
+    rushing_tds: toNum(pick(row, ["rushingTD", "rushTDProj"])),
+    receiving_yards: toNum(pick(row, ["receivingYards", "recYardsProj"])),
+    receiving_tds: toNum(pick(row, ["receivingTD", "recTDProj"])),
+    fantasy_points: toNum(pick(row, ["fantasyPoints", "fantasyProjection", "projFantasy"], null))
+  };
+}
+
+export function mapTank01Play(row = {}, defaults = {}) {
+  const season = toInt(row.season ?? defaults.season);
+  const week = toInt(row.week ?? defaults.week);
+  const posteam = normTeam(pick(row, ["posteam", "offenseTeam", "offense", "offenseAbbr"], defaults.posteam));
+  const defteam = normTeam(pick(row, ["defteam", "defenseTeam", "defense", "defenseAbbr"], defaults.defteam));
+  if (season == null || week == null || !posteam || !defteam) return null;
+  const epa = toNum(pick(row, ["epa", "expectedPointsAdded", "playEPA", "epaTotal"]));
+  const successRaw = pick(row, ["success", "isSuccess", "successFlag", "successful"], null);
+  let success = null;
+  if (typeof successRaw === "boolean") {
+    success = successRaw ? 1 : 0;
+  } else if (successRaw != null) {
+    const num = Number(successRaw);
+    success = Number.isFinite(num) ? (num > 0 ? 1 : 0) : null;
+  }
+  return {
+    season,
+    week,
+    posteam,
+    defteam,
+    epa,
+    success,
+    season_type: toStr(row.seasonType ?? row.season_type ?? defaults.season_type ?? "REG") || "REG"
+  };
+}
+
+export function extractFirstArray(payload) {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (typeof payload !== "object") return [];
+  for (const value of Object.values(payload)) {
+    const arr = extractFirstArray(value);
+    if (arr.length) return arr;
+  }
+  return [];
+}
+
+export default {
+  mapTank01Schedule,
+  mapTank01TeamWeek,
+  mapTank01PlayerWeek,
+  mapTank01Roster,
+  mapTank01DepthChart,
+  mapTank01Injury,
+  mapTank01Odds,
+  mapTank01Projection,
+  mapTank01Play,
+  extractFirstArray
+};

--- a/trainer/tests/backtest.js
+++ b/trainer/tests/backtest.js
@@ -2,7 +2,16 @@
 // Backtest ensemble performance across recent weeks.
 
 import { runTraining } from "../train_multi.js";
-import { loadSchedules, loadTeamWeekly } from "../dataSources.js";
+import {
+  loadBettingOdds,
+  loadDepthCharts,
+  loadInjuries,
+  loadPlayerProjections,
+  loadPlayerWeekly,
+  loadRostersWeekly,
+  loadSchedules,
+  loadTeamWeekly
+} from "../dataSources.js";
 
 const logloss = (probs, labels) => {
   if (!labels.length) return null;
@@ -35,6 +44,7 @@ function regression(points) {
 
 async function main() {
   const season = Number(process.env.SEASON ?? new Date().getFullYear());
+  await maybeExerciseTankSources(season);
   const schedules = await loadSchedules(season);
   const teamWeekly = await loadTeamWeekly(season);
   let prev = [];
@@ -145,3 +155,18 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+
+async function maybeExerciseTankSources(season) {
+  if (process.env.USE_TANK01_LOADERS?.toLowerCase() !== "true") return;
+  const tasks = [
+    loadSchedules(season),
+    loadTeamWeekly(season),
+    loadPlayerWeekly(season),
+    loadRostersWeekly(season),
+    loadDepthCharts(season),
+    loadInjuries(season),
+    loadBettingOdds(season),
+    loadPlayerProjections(season)
+  ];
+  await Promise.allSettled(tasks);
+}


### PR DESCRIPTION
## Summary
- add a shared Tank01 RapidAPI client with retry/backoff handling and normalization helpers
- integrate Tank01-backed schedules/stats/odds/projections into the trainer data sources with nflverse fallbacks
- document the new TANK01_API_KEY workflow and extend smoke/backtest tests to optionally exercise Tank01 loaders

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df564b4e8c8330bcc6725376e0abb5