### PR TITLE
Update documentation for Rotowire injury ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Train, evaluate, and serve NFL win probabilities using only open nflverse data â
    - `SEASON` (defaults to current year)
    - `WEEK` (defaults to 6; the trainer iterates from Week 1 up to this value if historical data exists)
    - `ANN_SEEDS`, `ANN_MAX_EPOCHS`, `BT_B`, etc. to tune ensemble search.
-   - `ROTOWIRE_ENABLED` (`true` to allow Rotowire injury fallbacks when nflverse rows are missing)
+   - `ROTOWIRE_ENABLED` (`true` is required for the Rotowire injury fetcher to run and write artifacts)
 3. Run the full ensemble trainer:
    ```bash
    npm run train:multi
    ```
-   This downloads nflverse data, builds features, fits every model, calibrates the blend, and writes artifacts under `artifacts/` for each completed week up to `WEEK`.
+   This downloads nflverse data, consumes the Rotowire injury artifacts, builds features, fits every model, calibrates the blend, and writes artifacts under `artifacts/` for each completed week up to `WEEK`.
 4. (Optional) Run the legacy single-week trainer for the logistic/tree hybrid only:
    ```bash
    npm run train
@@ -37,9 +37,9 @@ GitHub Actions can automate Step 3 on a schedule; copy `.github/workflows/train.
 
 ## Injury ingestion workflow
 
-`trainer/dataSources.js` still prefers the nflverse weekly injury CSVs. When those are empty or lag behind, you can enable the Rotowire fallback and refresh the artifacts before generating context packs:
+Injury data now ships exclusively from the Rotowire scraper artifacts emitted by `scripts/fetchRotowireInjuries.js`. Refresh the artifacts before generating context packs or rerunning training:
 
-1. Set `ROTOWIRE_ENABLED=true` in your shell.
+1. Set `ROTOWIRE_ENABLED=true` in your shell (required for the fetcher to execute).
 2. Run the fetcher for the target snapshot (pass any season/week you need):
    ```bash
    npm run fetch:injuries -- --season=2025 --week=6

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -1,7 +1,7 @@
 # Data ingestion cheat sheet
 
-This project relies exclusively on [nflverse](https://github.com/nflverse/) public datasets. The `trainer/dataSources.js`
-module wraps every feed with:
+This project relies on [nflverse](https://github.com/nflverse/) public datasets, with injuries sourced from Rotowire via
+`scripts/fetchRotowireInjuries.js`. The `trainer/dataSources.js` module wraps every feed with:
 
 - **Redundant mirrors** – GitHub release assets, `main` and `master` branches, and legacy `nfldata` fallbacks.
 - **Dynamic discovery** – manifests are resolved via the GitHub API so loaders know which seasons/files are available before
@@ -20,7 +20,7 @@ Use this table to understand what we load, how often nflverse updates it, and wh
 | Play-by-play | `releases/download/pbp/play_by_play_<season>.csv.gz` | Daily/weekly | EPA & success aggregates |
 | Weekly rosters | `releases/download/weekly_rosters/weekly_rosters_<season>.csv` | Daily | Context packs (starters) |
 | Depth charts | `releases/download/depth_charts/depth_charts_<season>.csv` | Daily | Context packs (starter mapping) |
-| Injuries | `releases/download/injuries/injuries_<season>.csv` (fallback `scripts/fetchRotowireInjuries.js`) | Daily (Thu-Sun heavy) | Context packs (injury report summaries) |
+| Injuries | Rotowire scraper artifacts (`artifacts/injuries_<season>_W<week>.json` via `scripts/fetchRotowireInjuries.js`) | Daily (Thu-Sun heavy) | Context packs (injury report summaries) |
 | Snap counts | `releases/download/snap_counts/snap_counts_<season>.csv` | Weekly | Available for usage-based context |
 | ESPN Total QBR | `releases/download/espn_data/espn_qbr_<season>.csv` | Weekly | QB form overlay |
 | PFR advanced team | `releases/download/pfr_advstats/pfr_advstats_team_<season>.csv` | Weekly | Team efficiency context |


### PR DESCRIPTION
## Summary
- update README quick start and injury workflow to describe Rotowire artifacts and ROTOWIRE_ENABLED usage
- revise data ingestion guide to point injuries to Rotowire scraper outputs instead of nflverse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05d27b960833082625cba1728d2dd