### PR TITLE
Add Rotowire injury fetch step to train workflow

### DIFF
--- a/.github/workflows/train.yaml
+++ b/.github/workflows/train.yaml
@@ -74,6 +74,13 @@ jobs:
           fi
           echo "WEEK=$WEEK" >> $GITHUB_OUTPUT
 
+      - name: Fetch Rotowire injuries
+        env:
+          ROTOWIRE_ENABLED: 'true'
+          SEASON: ${{ env.SEASON }}
+          WEEK: ${{ steps.resolve.outputs.WEEK }}
+        run: npm run fetch:injuries -- --season=$SEASON --week=$WEEK
+
       - name: Build context
         env:
           SEASON: ${{ env.SEASON }}


### PR DESCRIPTION
## Summary
- add a Rotowire injury fetch step to the training workflow
- ensure the new step uses the resolved season and week context
- keep build context step after fetching injuries to include new artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06299262c8330a8a4bf61ae82ae4e