### PR TITLE
Filter injury rows to current season

### DIFF
--- a/scripts/fetchRotowireInjuries.js
+++ b/scripts/fetchRotowireInjuries.js
@@ -104,6 +104,262 @@ function parseTable(html, meta) {
   return rows;
 }
 
+function parseGrid(html, meta) {
+  const rows = [];
+  if (!html) return rows;
+  const gridRegex = /<div[^>]*role=["']grid["'][^>]*>([\s\S]*?)<\/div>/gi;
+  let gMatch;
+  while ((gMatch = gridRegex.exec(html)) !== null) {
+    const gridHtml = gMatch[1];
+    if (!/Player/i.test(gridHtml) || !/Status/i.test(gridHtml)) continue;
+    const rowRegex = /<div[^>]*role=["']row["'][^>]*>([\s\S]*?)<\/div>/gi;
+    let rMatch;
+    while ((rMatch = rowRegex.exec(gridHtml)) !== null) {
+      const rowHtml = rMatch[1];
+      if (/role=["']columnheader["']/i.test(rowHtml)) continue;
+      const cellMatches = Array.from(
+        rowHtml.matchAll(/<(?:div|span)[^>]*role=["']gridcell["'][^>]*>([\s\S]*?)<\/(?:div|span)>/gi)
+      );
+      if (!cellMatches.length) continue;
+      const cells = cellMatches.map((c) => cleanText(c[1])).filter((txt) => txt);
+      if (!cells.length) continue;
+      const [player, position, injury, status, practice, notes] = cells;
+      if (!player || /player/i.test(player)) continue;
+      rows.push({
+        team: meta.team,
+        season: meta.season,
+        week: meta.week,
+        player,
+        position: position || null,
+        status: status || null,
+        injury: injury || null,
+        practice: practice || null,
+        notes: notes || null,
+        fetched_at: meta.fetchedAt,
+        source: 'rotowire'
+      });
+    }
+  }
+  return rows;
+}
+
+function pickString(...values) {
+  for (const val of values) {
+    if (typeof val === 'string' && val.trim()) return val.trim();
+  }
+  return null;
+}
+
+function pickDefined(...values) {
+  for (const val of values) {
+    if (val !== undefined && val !== null && val !== '') return val;
+  }
+  return undefined;
+}
+
+function parseSeasonNumber(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const firstYearMatch = trimmed.match(/(20\d{2})/);
+    if (firstYearMatch) {
+      const parsed = Number.parseInt(firstYearMatch[1], 10);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+  }
+  return null;
+}
+
+const TEAM_ABBR_MAP = new Map([
+  ['ARZ', 'ARI'],
+  ['JAC', 'JAX'],
+  ['KAN', 'KC'],
+  ['KCC', 'KC'],
+  ['SD', 'LAC'],
+  ['SDG', 'LAC'],
+  ['STL', 'LAR'],
+  ['LA', 'LAR'],
+  ['OAK', 'LV'],
+  ['WSH', 'WAS'],
+  ['WDC', 'WAS'],
+  ['TAM', 'TB'],
+  ['NOR', 'NO'],
+  ['GNB', 'GB'],
+  ['SFO', 'SF'],
+  ['NWE', 'NE'],
+  ['NJD', 'NYJ'],
+  ['NYA', 'NYJ'],
+  ['NYN', 'NYG']
+]);
+
+function normalizeTeam(value) {
+  if (!value) return null;
+  const cleaned = value.toString().trim().toUpperCase();
+  const mapped = TEAM_ABBR_MAP.get(cleaned);
+  if (mapped) return mapped;
+  if (TEAM_CODES.includes(cleaned)) return cleaned;
+  if (cleaned.length >= 3) {
+    const short = cleaned.slice(0, 3);
+    const shortMapped = TEAM_ABBR_MAP.get(short) || short;
+    if (TEAM_CODES.includes(shortMapped)) return shortMapped;
+  }
+  return null;
+}
+
+function createJsonCollector(meta) {
+  const rows = [];
+  const seen = new Set();
+
+  function maybePush(obj) {
+    if (!obj || typeof obj !== 'object') return;
+    const teamCandidate = pickString(
+      obj.team,
+      obj.teamAbbr,
+      obj.team_abbr,
+      obj.teamAbbrev,
+      obj.teamCode,
+      obj.team_code,
+      obj.team,
+      obj.teamShort,
+      obj.teamShortName,
+      obj.team_short,
+      obj.club,
+      obj.clubcode
+    );
+    const normalizedTeam = normalizeTeam(teamCandidate);
+    if (normalizedTeam && normalizedTeam !== meta.team) return;
+
+    const seasonCandidate = pickDefined(
+      obj.season,
+      obj.seasonYear,
+      obj.season_year,
+      obj.seasonId,
+      obj.season_id,
+      obj.seasonCode,
+      obj.season_code,
+      obj.year,
+      obj.gameSeason,
+      obj.seasonDisplay,
+      obj.season_display
+    );
+    const normalizedSeason = parseSeasonNumber(seasonCandidate);
+    if (normalizedSeason !== null && normalizedSeason !== meta.season) return;
+
+    const player = pickString(obj.player, obj.playerName, obj.name, obj.fullName, obj.displayName);
+    if (!player) return;
+
+    const position = pickString(obj.position, obj.pos, obj.positionAbbr, obj.position_abbr);
+    const status = pickString(
+      obj.status,
+      obj.gameStatus,
+      obj.statusShort,
+      obj.statusText,
+      obj.injuryStatus,
+      obj.status_label
+    );
+    const injury = pickString(obj.injury, obj.injuryDetail, obj.injury_desc, obj.injuryType, obj.bodyPart);
+    const practice = pickString(
+      obj.practice,
+      obj.practiceStatus,
+      obj.practiceParticipation,
+      obj.practiceText,
+      obj.practice_status
+    );
+    const notes = pickString(obj.notes, obj.note, obj.report, obj.analysis, obj.comment, obj.outlook);
+
+    if (!(status || injury || practice || notes)) return;
+
+    const key = `${player}|${status || ''}|${injury || ''}|${practice || ''}|${notes || ''}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    rows.push({
+      team: meta.team,
+      season: meta.season,
+      week: meta.week,
+      player,
+      position: position || null,
+      status: status || null,
+      injury: injury || null,
+      practice: practice || null,
+      notes: notes || null,
+      fetched_at: meta.fetchedAt,
+      source: 'rotowire'
+    });
+  }
+
+  function walk(node) {
+    if (!node) return;
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    if (typeof node === 'object') {
+      maybePush(node);
+      for (const value of Object.values(node)) walk(value);
+    }
+  }
+
+  return { rows, walk };
+}
+
+function parseEmbeddedJson(html, meta) {
+  const { rows, walk } = createJsonCollector(meta);
+
+  const jsonScriptRegex = /<script[^>]+type=["']application\/json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let match;
+  while ((match = jsonScriptRegex.exec(html)) !== null) {
+    const raw = match[1];
+    try {
+      const parsed = JSON.parse(raw);
+      walk(parsed);
+    } catch (err) {
+      // ignore parse issues for unrelated JSON blobs
+    }
+  }
+
+  const nextDataMatch = html.match(/<script[^>]*id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i);
+  if (nextDataMatch) {
+    try {
+      const parsed = JSON.parse(nextDataMatch[1]);
+      walk(parsed);
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  const nuxtMatch = html.match(/window\.__NUXT__=({[\s\S]*?});/);
+  if (nuxtMatch) {
+    try {
+      const parsed = JSON.parse(nuxtMatch[1]);
+      walk(parsed);
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  return rows;
+}
+
+function parseEmbeddedJsonObject(payload, meta) {
+  const { rows, walk } = createJsonCollector(meta);
+  walk(payload);
+  return rows;
+}
+
+function extractRows(html, meta) {
+  if (!html) return [];
+  const tableRows = parseTable(html, meta);
+  if (tableRows.length) return tableRows;
+
+  const gridRows = parseGrid(html, meta);
+  if (gridRows.length) return gridRows;
+
+  return parseEmbeddedJson(html, meta);
+}
+
 async function fetchTeamReport(team) {
   const url = new URL('https://www.rotowire.com/football/tables/injury-report.php');
   url.searchParams.set('team', team);
@@ -111,15 +367,62 @@ async function fetchTeamReport(team) {
   url.searchParams.set('season', String(season));
   url.searchParams.set('week', String(week));
 
-  const res = await fetch(url, {
-    headers: {
-      'User-Agent': 'PerdictionNFL/rotowire-ingest (+https://github.com/Perdiction-NFL)',
-      Accept: 'text/html,application/xhtml+xml'
+  const attempts = [url];
+
+  const ajaxUrl = new URL(url);
+  ajaxUrl.searchParams.set('type', 'ajax');
+  attempts.push(ajaxUrl);
+
+  const legacyAjaxUrl = new URL(url);
+  legacyAjaxUrl.searchParams.set('ajax', '1');
+  attempts.push(legacyAjaxUrl);
+
+  for (const attemptUrl of attempts) {
+    const res = await fetch(attemptUrl, {
+      headers: {
+        'User-Agent': 'PerdictionNFL/rotowire-ingest (+https://github.com/Perdiction-NFL)',
+        Accept: 'text/html,application/xhtml+xml,application/json;q=0.9'
+      }
+    });
+    if (!res.ok) {
+      if (attemptUrl === attempts[attempts.length - 1]) throw new Error(`HTTP ${res.status}`);
+      continue;
     }
-  });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const html = await res.text();
-  return parseTable(html, { team, season, week, fetchedAt });
+
+    const contentType = res.headers.get('content-type') || '';
+    let body;
+    let jsonPayload = null;
+    if (/application\/json/i.test(contentType)) {
+      try {
+        const json = await res.json();
+        jsonPayload = json && typeof json === 'object' ? json : null;
+        if (typeof json === 'string') body = json;
+        else if (json && typeof json === 'object') {
+          body = json.html || json.body || json.result || json.content || null;
+          if (!body) {
+            try {
+              body = JSON.stringify(json);
+            } catch (err) {
+              body = null;
+            }
+          }
+        }
+      } catch (err) {
+        body = null;
+      }
+    } else {
+      body = await res.text();
+    }
+
+    const html = typeof body === 'string' ? body : '';
+    let rows = extractRows(html, { team, season, week, fetchedAt });
+    if (!rows.length && jsonPayload) {
+      rows = parseEmbeddedJsonObject(jsonPayload, { team, season, week, fetchedAt });
+    }
+    if (rows.length) return rows;
+  }
+
+  return [];
 }
 
 async function main() {
@@ -129,6 +432,9 @@ async function main() {
     try {
       console.log(`[fetchRotowireInjuries] Fetching ${team} (${idx + 1}/${TEAM_CODES.length})`);
       const rows = await fetchTeamReport(team);
+      if (!rows.length) {
+        console.warn(`[fetchRotowireInjuries] ${team} returned 0 rows (no injuries or markup change?)`);
+      }
       aggregated.push(...rows);
     } catch (err) {
       console.warn(`[fetchRotowireInjuries] ${team} failed: ${err?.message || err}`);


### PR DESCRIPTION
## Summary
- add helpers to filter parsed Rotowire JSON by season metadata
- ignore archived injury entries that don't match the requested season

## Testing
- not run (network-dependent fetch command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0638754248330960886b17101156f