### PR TITLE
Fix hybrid arg parser to support equals syntax

### DIFF
--- a/scripts/hybridV2.js
+++ b/scripts/hybridV2.js
@@ -123,7 +123,15 @@ function parseArgs() {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (!arg.startsWith("--")) continue;
-    const key = arg.slice(2);
+    const withoutPrefix = arg.slice(2);
+    if (withoutPrefix.includes("=")) {
+      const [rawKey, ...rest] = withoutPrefix.split("=");
+      const key = rawKey;
+      const value = rest.join("=");
+      options[key] = value === "" ? true : value;
+      continue;
+    }
+    const key = withoutPrefix;
     const value = args[i + 1];
     if (value && !value.startsWith("--")) {
       options[key] = value;


### PR DESCRIPTION
## Summary
- allow the hybridV2 script argument parser to handle `--key=value` style options so CI passes the intended week

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e40383418c833092e48a66a0419d4d