### PR TITLE
Fix hybridV2 CLI argument parsing

### DIFF
--- a/scripts/hybridV2.js
+++ b/scripts/hybridV2.js
@@ -24,7 +24,17 @@ function parseArgs() {
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (!arg.startsWith("--")) continue;
-    const key = arg.slice(2);
+    const stripped = arg.slice(2);
+    if (stripped.includes("=")) {
+      const [rawKey, ...rest] = stripped.split("=");
+      const key = rawKey;
+      const value = rest.join("=");
+      if (key.length > 0) {
+        out[key] = value;
+      }
+      continue;
+    }
+    const key = stripped;
     const next = args[i + 1];
     if (next && !next.startsWith("--")) {
       out[key] = next;


### PR DESCRIPTION
## Summary
- update the hybridV2 script's argument parser to support --flag=value syntax used in CI

## Testing
- node scripts/hybridV2.js --season=2025 --week=4

------
https://chatgpt.com/codex/tasks/task_e_68e41e0df8c88330bc2f56553d24834d