### PR TITLE
Log missing Rotowire artifacts during context build

### DIFF
--- a/.github/workflows/train.yaml
+++ b/.github/workflows/train.yaml
@@ -81,6 +81,13 @@ jobs:
           WEEK: ${{ steps.resolve.outputs.WEEK }}
         run: npm run fetch:injuries -- --season=$SEASON --week=$WEEK
 
+      - name: Fetch Rotowire markets
+        env:
+          ROTOWIRE_ENABLED: 'true'
+          SEASON: ${{ env.SEASON }}
+          WEEK: ${{ steps.resolve.outputs.WEEK }}
+        run: npm run fetch:markets -- --season=$SEASON --week=$WEEK
+
       - name: Build context
         env:
           SEASON: ${{ env.SEASON }}

--- a/README.md
+++ b/README.md
@@ -35,17 +35,22 @@ Train, evaluate, and serve NFL win probabilities using only open nflverse data â
 
 GitHub Actions can automate Step 3 on a schedule; copy `.github/workflows/train.yml`, set secrets if required, and enable Actions in your fork.
 
-## Injury ingestion workflow
+## Rotowire ingestion workflow
 
-Injury data now ships exclusively from the Rotowire scraper artifacts emitted by `scripts/fetchRotowireInjuries.js`. Refresh the artifacts before generating context packs or rerunning training:
+Injury and betting market context both ship from Rotowire scraper artifacts emitted by the scripts under `scripts/`. Refresh them before generating context packs or rerunning training so the trainer has the latest reports and odds snapshot:
 
-1. Set `ROTOWIRE_ENABLED=true` in your shell (required for the fetcher to execute).
-2. Run the fetcher for the target snapshot (pass any season/week you need):
+1. Set `ROTOWIRE_ENABLED=true` in your shell (required for the fetchers to execute).
+2. Run the injury fetcher for the target snapshot (pass any season/week you need):
    ```bash
    npm run fetch:injuries -- --season=2025 --week=6
    ```
    The script throttles between team requests, parses the Rotowire HTML table, and writes `artifacts/injuries_<season>_W<week>.json` plus `artifacts/injuries_current.json`.
-3. Re-run `npm run build:context` or `npm run train:multi` so the new injury rows flow into the summaries and per-game context.
+3. Run the betting markets fetcher for the same snapshot:
+   ```bash
+   npm run fetch:markets -- --season=2025 --week=6
+   ```
+   This pulls the Rotowire betting tables, normalises prices/lines, and writes `artifacts/markets_<season>_W<week>.json` plus `artifacts/markets_current.json`.
+4. Re-run `npm run build:context` or `npm run train:multi` so the refreshed artifacts flow into summaries, per-game context, and ensemble training.
 
 ## Produced artifacts
 Each successful `train:multi` run refreshes or adds:

--- a/trainer/databases.js
+++ b/trainer/databases.js
@@ -580,6 +580,17 @@ export async function buildContextDB(season, weekCap, outDir = "artifacts") {
       loadMarketsDS(y)
     ]);
 
+  if (!injuries?.length) {
+    console.warn(
+      '[context] No Rotowire injury artifacts were loaded – run `npm run fetch:injuries` before building context if you expect current reports.'
+    );
+  }
+  if (!marketRows?.length) {
+    console.warn(
+      '[context] No Rotowire market artifacts were loaded – run `npm run fetch:markets` before building context if betting data should be present.'
+    );
+  }
+
   // build summaries (bounded by cap)
   const injSummary   = summarizeInjuries(injuries, cap);
   const depthChange  = summarizeDepthChange(depthCharts, cap);


### PR DESCRIPTION
## Summary
- warn during context builds when Rotowire injuries or markets data are absent
- direct operators to run the respective fetch scripts before rebuilding context

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43d76ea34833088b6c0f5cd04182e