### PR TITLE
Handle missing yardage totals when building context

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fetch:injuries": "node scripts/fetchRotowireInjuries.js",
     "fetch:markets": "node scripts/fetchRotowireMarkets.js",
     "hybrid:v2": "node scripts/hybridV2.js",
-    "test": "node trainer/tests/model_ann.test.js && node trainer/tests/smoke.js"
+    "test": "node trainer/tests/contextPack.test.js && node trainer/tests/model_ann.test.js && node trainer/tests/smoke.js"
   },
   "dependencies": {
     "axios": "^1.7.7",

--- a/trainer/contextPack.js
+++ b/trainer/contextPack.js
@@ -34,6 +34,96 @@ function rollingAvg(arr, k) {
   return out;
 }
 
+const OFFENSE_WEEKLY_KEYS = [
+  "total_yards",
+  "off_total_yards",
+  "off_total_yds",
+  "yards_gained",
+  "total_yards_gained",
+  "total_yds",
+  "yards_gained_total",
+  "off_total_yards_gained"
+];
+
+const OFFENSE_CUM_KEYS = [
+  "off_total_yds_s2d",
+  "total_yards_s2d",
+  "total_yards_gained_s2d",
+  "off_total_yards_s2d",
+  "off_total_yards_gained_s2d"
+];
+
+const OFFENSE_PASS_WEEKLY_KEYS = [
+  "passing_yards",
+  "pass_yards",
+  "pass_yds",
+  "off_pass_yards",
+  "off_pass_yds"
+];
+
+const OFFENSE_PASS_CUM_KEYS = ["off_pass_yds_s2d", "passing_yards_s2d"];
+
+const OFFENSE_RUSH_WEEKLY_KEYS = [
+  "rushing_yards",
+  "rush_yards",
+  "rush_yds",
+  "off_rush_yards",
+  "off_rush_yds"
+];
+
+const OFFENSE_RUSH_CUM_KEYS = ["off_rush_yds_s2d", "rushing_yards_s2d"];
+
+const DEFENSE_WEEKLY_KEYS = [
+  "yards_allowed",
+  "total_yards_allowed",
+  "def_total_yards",
+  "def_total_yds",
+  "yards_allowed_total",
+  "yards_allowed_gained",
+  "def_total_yards_allowed",
+  "def_total_yards_gained"
+];
+
+const DEFENSE_CUM_KEYS = [
+  "def_total_yds_s2d",
+  "yards_allowed_s2d",
+  "yards_allowed_total_s2d",
+  "def_total_yards_s2d",
+  "def_total_yards_allowed_s2d"
+];
+
+const DEFENSE_PASS_WEEKLY_KEYS = [
+  "passing_yards_allowed",
+  "pass_yards_allowed",
+  "pass_yards_against",
+  "opp_pass_yards",
+  "opp_pass_yds",
+  "def_pass_yards",
+  "def_pass_yds"
+];
+
+const DEFENSE_PASS_CUM_KEYS = [
+  "def_pass_yds_s2d",
+  "pass_yards_allowed_s2d",
+  "opp_pass_yards_s2d"
+];
+
+const DEFENSE_RUSH_WEEKLY_KEYS = [
+  "rushing_yards_allowed",
+  "rush_yards_allowed",
+  "rush_yards_against",
+  "opp_rush_yards",
+  "opp_rush_yds",
+  "def_rush_yards",
+  "def_rush_yds"
+];
+
+const DEFENSE_RUSH_CUM_KEYS = [
+  "def_rush_yds_s2d",
+  "rushing_yards_allowed_s2d",
+  "opp_rush_yards_s2d"
+];
+
 function gameKey(season, week, home, away) {
   return `${season}-W${String(week).padStart(2, "0")}-${home}-${away}`;
 }
@@ -181,24 +271,57 @@ function latestQBR(entries = [], week) {
   return val ?? entries.at(-1)?.qbr ?? null;
 }
 
-export async function buildContextForWeek(season, week) {
+export async function buildContextForWeek(season, week, overrides = {}) {
   const y = Number(season);
   const w = Number(week);
   if (!Number.isFinite(y) || !Number.isFinite(w)) return [];
 
-  const schedules = await loadSchedules(y);
+  let schedules = overrides.schedules;
+  if (!Array.isArray(schedules)) {
+    schedules = await loadSchedules(y);
+  }
+
   let teamWeekly = [];
+  if (Object.prototype.hasOwnProperty.call(overrides, "teamWeekly")) {
+    teamWeekly = overrides.teamWeekly ?? [];
+  } else {
+    try { teamWeekly = await loadTeamWeekly(y); } catch (err) { console.warn("teamWeekly load failed", err?.message ?? err); }
+  }
+
   let playerWeekly = [];
+  if (Object.prototype.hasOwnProperty.call(overrides, "playerWeekly")) {
+    playerWeekly = overrides.playerWeekly ?? [];
+  } else {
+    try { playerWeekly = await loadPlayerWeekly(y); } catch (err) { console.warn("playerWeekly load failed", err?.message ?? err); }
+  }
+
   let injuries = [];
+  if (Object.prototype.hasOwnProperty.call(overrides, "injuries")) {
+    injuries = overrides.injuries ?? [];
+  } else {
+    try { injuries = await loadInjuries(y); } catch (err) { console.warn("injuries load failed", err?.message ?? err); }
+  }
+
   let qbrRows = [];
+  if (Object.prototype.hasOwnProperty.call(overrides, "qbrRows")) {
+    qbrRows = overrides.qbrRows ?? [];
+  } else {
+    try { qbrRows = await loadESPNQBR(y); } catch (err) { /* optional */ }
+  }
+
   let eloRows = [];
+  if (Object.prototype.hasOwnProperty.call(overrides, "eloRows")) {
+    eloRows = overrides.eloRows ?? [];
+  } else {
+    try { eloRows = await loadElo(y); } catch (err) { console.warn("elo load failed", err?.message ?? err); }
+  }
+
   let marketRows = [];
-  try { teamWeekly = await loadTeamWeekly(y); } catch (err) { console.warn("teamWeekly load failed", err?.message ?? err); }
-  try { playerWeekly = await loadPlayerWeekly(y); } catch (err) { console.warn("playerWeekly load failed", err?.message ?? err); }
-  try { injuries = await loadInjuries(y); } catch (err) { console.warn("injuries load failed", err?.message ?? err); }
-  try { qbrRows = await loadESPNQBR(y); } catch (err) { /* optional */ }
-  try { eloRows = await loadElo(y); } catch (err) { console.warn("elo load failed", err?.message ?? err); }
-  try { marketRows = await loadMarkets(y); } catch (err) { console.warn("market load failed", err?.message ?? err); }
+  if (Object.prototype.hasOwnProperty.call(overrides, "marketRows")) {
+    marketRows = overrides.marketRows ?? [];
+  } else {
+    try { marketRows = await loadMarkets(y); } catch (err) { console.warn("market load failed", err?.message ?? err); }
+  }
 
   const games = schedules.filter((g) => Number(g.season) === y && Number(g.week) === w);
   if (!games.length) return [];
@@ -221,11 +344,36 @@ export async function buildContextForWeek(season, week) {
 
   for (const [team, rows] of byTeam.entries()) {
     rows.sort((a, b) => a._week - b._week);
-    const yardsFor = extractWeeklySeries(rows, ["total_yards", "off_total_yards", "off_total_yds", "yards_gained"], ["off_total_yds_s2d", "total_yards_s2d"]);
-    const yardsAgainst = extractWeeklySeries(rows, ["yards_allowed", "total_yards_allowed", "def_total_yards", "def_total_yds"], ["def_total_yds_s2d", "yards_allowed_s2d"]);
-    const passYards = extractWeeklySeries(rows, ["passing_yards", "pass_yards", "pass_yds"], ["off_pass_yds_s2d"]);
-    const passAtt = extractWeeklySeries(rows, ["pass_attempts", "passing_attempts", "attempts", "pass_att"], ["off_pass_att_s2d"]);
+    let yardsFor = extractWeeklySeries(rows, OFFENSE_WEEKLY_KEYS, OFFENSE_CUM_KEYS);
+    let yardsAgainst = extractWeeklySeries(rows, DEFENSE_WEEKLY_KEYS, DEFENSE_CUM_KEYS);
+    const passYards = extractWeeklySeries(rows, OFFENSE_PASS_WEEKLY_KEYS, OFFENSE_PASS_CUM_KEYS);
+    const rushYards = extractWeeklySeries(rows, OFFENSE_RUSH_WEEKLY_KEYS, OFFENSE_RUSH_CUM_KEYS);
+    const defPassYards = extractWeeklySeries(rows, DEFENSE_PASS_WEEKLY_KEYS, DEFENSE_PASS_CUM_KEYS);
+    const defRushYards = extractWeeklySeries(rows, DEFENSE_RUSH_WEEKLY_KEYS, DEFENSE_RUSH_CUM_KEYS);
+    const passAtt = extractWeeklySeries(
+      rows,
+      ["pass_attempts", "passing_attempts", "attempts", "pass_att"],
+      ["off_pass_att_s2d"]
+    );
     const sacks = extractWeeklySeries(rows, ["sacks", "sacks_taken", "qb_sacked"], ["off_sacks_taken_s2d"]);
+
+    yardsFor = yardsFor.map((value, idx) => {
+      const numVal = toNum(value, null);
+      if (Number.isFinite(numVal)) return numVal;
+      const pass = toNum(passYards[idx], null);
+      const rush = toNum(rushYards[idx], null);
+      if (!Number.isFinite(pass) && !Number.isFinite(rush)) return null;
+      return (Number.isFinite(pass) ? pass : 0) + (Number.isFinite(rush) ? rush : 0);
+    });
+
+    yardsAgainst = yardsAgainst.map((value, idx) => {
+      const numVal = toNum(value, null);
+      if (Number.isFinite(numVal)) return numVal;
+      const pass = toNum(defPassYards[idx], null);
+      const rush = toNum(defRushYards[idx], null);
+      if (!Number.isFinite(pass) && !Number.isFinite(rush)) return null;
+      return (Number.isFinite(pass) ? pass : 0) + (Number.isFinite(rush) ? rush : 0);
+    });
 
     const ypaSeries = passYards.map((yds, idx) => {
       const yards = toNum(yds, null);

--- a/trainer/tests/contextPack.test.js
+++ b/trainer/tests/contextPack.test.js
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { buildContextForWeek } from "../contextPack.js";
+
+function makeTeamRow({
+  season,
+  week,
+  team,
+  passYards,
+  rushYards,
+  passAllowed,
+  rushAllowed,
+  passAtt,
+  sacks
+}) {
+  return {
+    season,
+    week,
+    team,
+    passing_yards: passYards,
+    rushing_yards: rushYards,
+    passing_yards_allowed: passAllowed,
+    rushing_yards_allowed: rushAllowed,
+    pass_attempts: passAtt,
+    sacks
+  };
+}
+
+(async () => {
+  const season = 2025;
+  const week = 4;
+  const schedules = [
+    {
+      season,
+      week,
+      home_team: "ARI",
+      away_team: "SEA",
+      roof: "outdoor"
+    }
+  ];
+
+  const teamWeekly = [
+    makeTeamRow({
+      season,
+      week: 1,
+      team: "ARI",
+      passYards: 260,
+      rushYards: 140,
+      passAllowed: 210,
+      rushAllowed: 140,
+      passAtt: 30,
+      sacks: 2
+    }),
+    makeTeamRow({
+      season,
+      week: 2,
+      team: "ARI",
+      passYards: 250,
+      rushYards: 130,
+      passAllowed: 220,
+      rushAllowed: 140,
+      passAtt: 29,
+      sacks: 3
+    }),
+    makeTeamRow({
+      season,
+      week: 3,
+      team: "ARI",
+      passYards: 270,
+      rushYards: 150,
+      passAllowed: 200,
+      rushAllowed: 130,
+      passAtt: 31,
+      sacks: 1
+    }),
+    makeTeamRow({
+      season,
+      week: 1,
+      team: "SEA",
+      passYards: 255,
+      rushYards: 135,
+      passAllowed: 215,
+      rushAllowed: 145,
+      passAtt: 28,
+      sacks: 2
+    }),
+    makeTeamRow({
+      season,
+      week: 2,
+      team: "SEA",
+      passYards: 265,
+      rushYards: 145,
+      passAllowed: 225,
+      rushAllowed: 145,
+      passAtt: 30,
+      sacks: 2
+    }),
+    makeTeamRow({
+      season,
+      week: 3,
+      team: "SEA",
+      passYards: 260,
+      rushYards: 145,
+      passAllowed: 220,
+      rushAllowed: 145,
+      passAtt: 29,
+      sacks: 1
+    })
+  ];
+
+  const context = await buildContextForWeek(season, week, {
+    schedules,
+    teamWeekly,
+    playerWeekly: [],
+    injuries: [],
+    qbrRows: [],
+    eloRows: [],
+    marketRows: []
+  });
+
+  assert.strictEqual(context.length, 1, "Expected one matchup in test context");
+  const matchup = context[0];
+  const { home, away } = matchup.context.rolling_strength;
+
+  assert(Number.isFinite(home.yds_for_3g), "Home rolling yards for should be finite");
+  assert(Number.isFinite(home.net_yds_3g), "Home rolling net yards should be finite");
+  assert(Number.isFinite(away.yds_for_3g), "Away rolling yards for should be finite");
+  assert(Number.isFinite(away.net_yds_3g), "Away rolling net yards should be finite");
+
+  const expectedHomeFor = ((260 + 140) + (250 + 130) + (270 + 150)) / 3;
+  const expectedHomeAgainst = ((210 + 140) + (220 + 140) + (200 + 130)) / 3;
+  const expectedAwayFor = ((255 + 135) + (265 + 145) + (260 + 145)) / 3;
+  const expectedAwayAgainst = ((215 + 145) + (225 + 145) + (220 + 145)) / 3;
+
+  assert(Math.abs(home.yds_for_3g - expectedHomeFor) < 1e-9, "Home rolling offense mismatch");
+  assert(Math.abs(home.yds_against_3g - expectedHomeAgainst) < 1e-9, "Home rolling defense mismatch");
+  assert(Math.abs(away.yds_for_3g - expectedAwayFor) < 1e-9, "Away rolling offense mismatch");
+  assert(Math.abs(away.yds_against_3g - expectedAwayAgainst) < 1e-9, "Away rolling defense mismatch");
+
+  console.log("contextPack rolling strength test passed");
+})();


### PR DESCRIPTION
## Summary
- add explicit offensive and defensive pass/rush yard aliases so context building can recover missing totals
- fall back to summing pass and rush yardage when total yard figures are absent to populate rolling strength metrics
- update the context pack test to prove the new fallbacks yield non-null rolling averages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e447769a9c8330a32cf16a7c0f052b