### PR TITLE
Add Rotowire weather ingestion and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ Injury and betting market context both ship from Rotowire scraper artifacts emit
    npm run fetch:markets -- --season=2025 --week=6
    ```
    This pulls the Rotowire betting tables, normalises prices/lines, and writes `artifacts/markets_<season>_W<week>.json` plus `artifacts/markets_current.json`.
-4. Re-run `npm run build:context` or `npm run train:multi` so the refreshed artifacts flow into summaries, per-game context, and ensemble training.
+4. Capture the weather forecasts from Rotowire's daily report:
+   ```bash
+   npm run fetch:weather -- --season=2025 --week=6
+   ```
+   The scraper parses `https://www.rotowire.com/football/weather.php`, extracts per-game conditions, and writes `artifacts/weather_<season>_W<week>.json` alongside `artifacts/weather_current.json` for the latest snapshot.
+5. Re-run `npm run build:context` or `npm run train:multi` so the refreshed artifacts flow into summaries, per-game context, and ensemble training.
 
 ## Produced artifacts
 Each successful `train:multi` run refreshes or adds:

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -22,6 +22,7 @@ Use this table to understand what we load, how often nflverse updates it, and wh
 | Depth charts | `releases/download/depth_charts/depth_charts_<season>.csv` | Daily | Context packs (starter mapping) |
 | Injuries | Rotowire scraper artifacts (`artifacts/injuries_<season>_W<week>.json` via `scripts/fetchRotowireInjuries.js`) | Daily (Thu-Sun heavy) | Context packs (injury report summaries) |
 | Betting markets | Rotowire betting artifacts (`artifacts/markets_<season>_W<week>.json` via `scripts/fetchRotowireMarkets.js`, sourced from `https://www.rotowire.com/betting/nfl/tables/nfl-games-by-market.php?week=<week>`) | Daily in-season | Context packs (market snapshot, marketing/betting enrichments) |
+| Weather forecasts | Rotowire weather artifacts (`artifacts/weather_<season>_W<week>.json` via `scripts/fetchRotowireWeather.js`, scraped from `https://www.rotowire.com/football/weather.php`) | Daily in-season | Context packs (game day conditions) & feature builders (weather features) |
 | Snap counts | `releases/download/snap_counts/snap_counts_<season>.csv` | Weekly | Available for usage-based context |
 | ESPN Total QBR | `releases/download/espn_data/espn_qbr_<season>.csv` | Weekly | QB form overlay |
 | PFR advanced team | `releases/download/pfr_advstats/pfr_advstats_team_<season>.csv` | Weekly | Team efficiency context |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -986,7 +986,7 @@ components:
 
     ContextPayload:
       type: array
-      description: Aggregated injuries, depth charts, usage, and venue context
+      description: Aggregated injuries, depth charts, usage, venue, market, and weather context
       items:
         $ref: "#/components/schemas/ContextGame"
 
@@ -1018,6 +1018,8 @@ components:
           $ref: "#/components/schemas/ContextRollingStrength"
         venue:
           $ref: "#/components/schemas/ContextVenue"
+        weather:
+          $ref: "#/components/schemas/ContextWeather"
         elo:
           type: number
           nullable: true
@@ -1103,6 +1105,69 @@ components:
         surface:
           type: string
       additionalProperties: true
+
+    ContextWeather:
+      type: object
+      properties:
+        summary:
+          type: string
+          nullable: true
+        details:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        temperature_f:
+          type: number
+          nullable: true
+        precipitation_chance:
+          type: number
+          nullable: true
+          description: Percentage chance of precipitation (0-100)
+        wind_mph:
+          type: number
+          nullable: true
+        impact_score:
+          type: number
+          nullable: true
+          description: Heuristic 0-1 severity score derived from weather notes
+        kickoff_display:
+          type: string
+          nullable: true
+        location:
+          type: string
+          nullable: true
+        forecast_provider:
+          type: string
+          nullable: true
+        forecast_links:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContextWeatherLink"
+        icon:
+          type: string
+          nullable: true
+          description: URL pointing to the forecast icon
+        fetched_at:
+          type: string
+          format: date-time
+          nullable: true
+        is_dome:
+          type: boolean
+          nullable: true
+      additionalProperties: true
+
+    ContextWeatherLink:
+      type: object
+      properties:
+        label:
+          type: string
+          nullable: true
+        url:
+          type: string
+          format: uri
+      required: [url]
 
     ExplainPayload:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "cheerio": "^1.0.0",
         "csv-parse": "^5.5.6",
         "ml-cart": "^2.0.1",
         "ml-logistic-regression": "^2.0.0",
@@ -51,6 +52,12 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -64,6 +71,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -74,6 +123,34 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csv-parse": {
@@ -91,6 +168,61 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -103,6 +235,31 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -295,6 +452,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-any-array": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
@@ -407,17 +607,114 @@
         "ml-array-rescale": "^1.3.7"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "resolve:week": "node scripts/resolveWeek.js",
     "fetch:injuries": "node scripts/fetchRotowireInjuries.js",
     "fetch:markets": "node scripts/fetchRotowireMarkets.js",
-    "test": "node trainer/tests/model_ann.test.js && node trainer/tests/smoke.js"
+    "fetch:weather": "node scripts/fetchRotowireWeather.js",
+    "test": "node trainer/tests/model_ann.test.js && node trainer/tests/weatherContext.test.js && node trainer/tests/smoke.js"
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "cheerio": "^1.0.0",
     "ml-cart": "^2.0.1",
     "ml-logistic-regression": "^2.0.0",
     "ml-matrix": "^6.11.0",

--- a/scripts/fetchRotowireWeather.js
+++ b/scripts/fetchRotowireWeather.js
@@ -1,0 +1,298 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import axios from "axios";
+import { load } from "cheerio";
+
+const ROTOWIRE_ENABLED = process.env.ROTOWIRE_ENABLED === "true";
+
+if (!ROTOWIRE_ENABLED) {
+  console.log('[fetchRotowireWeather] ROTOWIRE_ENABLED !== "true"; skipping fetch.');
+  process.exit(0);
+}
+
+const TEAM_NAME_TO_CODE = new Map([
+  ["49ERS", "SF"],
+  ["NINERS", "SF"],
+  ["BEARS", "CHI"],
+  ["BENGALS", "CIN"],
+  ["BILLS", "BUF"],
+  ["BRONCOS", "DEN"],
+  ["BROWNS", "CLE"],
+  ["BUCCANEERS", "TB"],
+  ["BUCS", "TB"],
+  ["CARDINALS", "ARI"],
+  ["CHARGERS", "LAC"],
+  ["CHIEFS", "KC"],
+  ["COLTS", "IND"],
+  ["COMMANDERS", "WAS"],
+  ["COWBOYS", "DAL"],
+  ["DOLPHINS", "MIA"],
+  ["EAGLES", "PHI"],
+  ["FALCONS", "ATL"],
+  ["GIANTS", "NYG"],
+  ["JAGUARS", "JAX"],
+  ["JAGS", "JAX"],
+  ["JETS", "NYJ"],
+  ["LIONS", "DET"],
+  ["PACKERS", "GB"],
+  ["PANTHERS", "CAR"],
+  ["PATRIOTS", "NE"],
+  ["RAIDERS", "LV"],
+  ["RAMS", "LAR"],
+  ["RAVENS", "BAL"],
+  ["SAINTS", "NO"],
+  ["SEAHAWKS", "SEA"],
+  ["STEELERS", "PIT"],
+  ["TEXANS", "HOU"],
+  ["TITANS", "TEN"],
+  ["VIKINGS", "MIN"]
+]);
+
+const argv = process.argv.slice(2);
+const cliOptions = {};
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  if (!arg.startsWith("--")) continue;
+  const [key, rawVal] = arg.split("=");
+  if (rawVal !== undefined) {
+    cliOptions[key.slice(2)] = rawVal;
+  } else if (i + 1 < argv.length && !argv[i + 1].startsWith("--")) {
+    cliOptions[key.slice(2)] = argv[i + 1];
+    i += 1;
+  } else {
+    cliOptions[key.slice(2)] = true;
+  }
+}
+
+const now = new Date();
+const season = Number.parseInt(cliOptions.season ?? now.getUTCFullYear(), 10);
+if (!Number.isFinite(season)) {
+  console.error('[fetchRotowireWeather] Invalid --season');
+  process.exit(1);
+}
+const week = Number.parseInt(cliOptions.week ?? cliOptions.w ?? cliOptions.gameweek ?? 0, 10);
+if (!Number.isFinite(week) || week <= 0) {
+  console.error('[fetchRotowireWeather] Provide --week (1-22).');
+  process.exit(1);
+}
+
+const fetchedAt = new Date().toISOString();
+const artifactsDir = path.resolve(process.cwd(), "artifacts");
+
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+function clean(text) {
+  if (!text) return "";
+  return text
+    .replace(/\s+/g, " ")
+    .replace(/\u00a0/g, " ")
+    .trim();
+}
+
+function canonical(name) {
+  return clean(name)
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+}
+
+function extractTeamCode($team) {
+  if (!$team || !$team.length) return null;
+  const imgSrc = $team.find("img").attr("src") || "";
+  const imgMatch = imgSrc.match(/\/([A-Z]{2,3})\.svg/i);
+  if (imgMatch) {
+    return imgMatch[1].toUpperCase();
+  }
+  const href = $team.attr("href") || "";
+  const slug = href.split("/").pop() || "";
+  if (slug) {
+    const slugParts = slug.split("-");
+    const last = slugParts.at(-1);
+    if (last && last.length <= 3) {
+      return last.toUpperCase();
+    }
+  }
+  const label = canonical($team.text());
+  if (!label) return null;
+  return TEAM_NAME_TO_CODE.get(label) || null;
+}
+
+function parseTemperature(details, isDome) {
+  const match = details.match(/(-?\d+(?:\.\d+)?)\s*°?\s*F/i);
+  if (match) return Number.parseFloat(match[1]);
+  return isDome ? 70 : null;
+}
+
+function parsePrecip(details, isDome) {
+  if (isDome) return 0;
+  const match = details.match(/(\d+(?:\.\d+)?)%\s+chance of (?:precipitation|rain|showers)/i);
+  if (match) return Number.parseFloat(match[1]);
+  return null;
+}
+
+function inferWind(text, isDome) {
+  if (isDome) return 0;
+  const lower = text.toLowerCase();
+  const mph = lower.match(/(\d+(?:\.\d+)?)\s*mph/);
+  if (mph) return Number.parseFloat(mph[1]);
+  const patterns = [
+    { regex: /calm (?:conditions|winds?)/i, value: 2 },
+    { regex: /light (?:breeze|winds?)/i, value: 7 },
+    { regex: /breezy/i, value: 12 },
+    { regex: /moderate (?:breeze|winds?)/i, value: 15 },
+    { regex: /steady winds?/i, value: 16 },
+    { regex: /gusty/i, value: 20 },
+    { regex: /strong (?:breeze|winds?)/i, value: 24 },
+    { regex: /howling winds?/i, value: 28 }
+  ];
+  for (const { regex, value } of patterns) {
+    if (regex.test(text)) return value;
+  }
+  return null;
+}
+
+function inferImpact({ notes, details, isDome, precip, wind, temperature }) {
+  if (isDome) return 0;
+  const text = `${details} ${notes}`.toLowerCase();
+  if (!text.trim()) return null;
+  const checks = [
+    { regex: /(minimal impact|not have a significant impact|little impact)/i, score: 0.1 },
+    { regex: /(light breeze|light winds?)/i, score: 0.2 },
+    { regex: /(moderate breeze|moderate winds?|steady winds?)/i, score: 0.35 },
+    { regex: /(gusty|strong winds?|heavy rain|downpour|snow|slick field|blustery)/i, score: 0.6 },
+    { regex: /(may result in some inaccurate passes|missed kicks|difficult kicking)/i, score: 0.45 },
+    { regex: /(significant impact|major impact)/i, score: 0.65 }
+  ];
+  let score = null;
+  for (const { regex, score: s } of checks) {
+    if (regex.test(text)) {
+      score = score == null ? s : Math.max(score, s);
+    }
+  }
+  if (score == null) {
+    if (typeof wind === "number") {
+      if (wind >= 25) score = 0.75;
+      else if (wind >= 18) score = 0.55;
+      else if (wind >= 12) score = 0.35;
+      else if (wind >= 6) score = 0.2;
+    }
+  }
+  if (score == null && typeof precip === "number") {
+    if (precip >= 70) score = 0.65;
+    else if (precip >= 50) score = 0.45;
+  }
+  if (score == null && typeof temperature === "number") {
+    if (temperature <= 25) score = 0.5;
+    else if (temperature >= 90) score = 0.35;
+  }
+  return score;
+}
+
+function parseLocation(details) {
+  const match = details.match(/in\s+([^.,]+?)(?:\s+at|\.|,)/i);
+  if (match) {
+    const loc = clean(match[1]);
+    if (loc) return loc;
+  }
+  return null;
+}
+
+function parseProvider(details) {
+  const match = details.match(/According to\s+([^,]+),/i);
+  if (match) return clean(match[1]);
+  return null;
+}
+
+async function fetchWeatherHtml() {
+  const url = "https://www.rotowire.com/football/weather.php";
+  const response = await axios.get(url, {
+    headers: { "User-Agent": USER_AGENT, Accept: "text/html" },
+    timeout: 15000
+  });
+  return response.data;
+}
+
+async function main() {
+  const html = await fetchWeatherHtml();
+  const $ = load(html);
+
+  const boxes = $(".weather-box");
+  if (!boxes.length) {
+    console.warn("[fetchRotowireWeather] No weather boxes found on page.");
+  }
+
+  const records = [];
+  boxes.each((_, el) => {
+    const $box = $(el);
+    const $away = $box.find(".weather-box__team.is-visit");
+    const $home = $box.find(".weather-box__team.is-home");
+    const awayTeam = extractTeamCode($away);
+    const homeTeam = extractTeamCode($home);
+    if (!homeTeam || !awayTeam) return;
+
+    const summary = clean($box.find(".weather-box__weather .heading").text());
+    const detail = clean($box.find(".weather-box__weather .text-80").text());
+    const notes = clean($box.find(".weather-box__notes").text());
+    const kickoff = clean($box.find(".weather-box__date").text());
+    const icon = clean($box.find(".weather-box__icon").attr("src"));
+    const provider = parseProvider(detail);
+    const isDome = /domed stadium|indoors?|roof closed/i.test(detail) || /indoors?|roof closed/i.test(notes);
+    const temperatureF = parseTemperature(detail, isDome);
+    const precipitationChance = parsePrecip(detail, isDome);
+    const windMph = inferWind(`${detail} ${notes}`, isDome);
+    const impactScore = inferImpact({ notes, details: detail, isDome, precip: precipitationChance, wind: windMph, temperature: temperatureF });
+    const location = parseLocation(detail) || null;
+
+    const links = [];
+    $box.find(".weather-box__forecasts a").each((__, link) => {
+      const href = clean($(link).attr("href"));
+      const label = clean($(link).text());
+      if (href) {
+        links.push({ label: label || null, url: href });
+      }
+    });
+
+    const record = {
+      season,
+      week,
+      home_team: homeTeam,
+      away_team: awayTeam,
+      home_name: clean($home.text()) || null,
+      away_name: clean($away.text()) || null,
+      game_key: `${season}-W${String(week).padStart(2, "0")}-${homeTeam}-${awayTeam}`,
+      kickoff_display: kickoff || null,
+      summary: summary || null,
+      details: detail || null,
+      notes: notes || null,
+      location,
+      forecast_provider: provider,
+      icon: icon || null,
+      temperature_f: typeof temperatureF === "number" ? Number(temperatureF.toFixed(1)) : null,
+      precipitation_chance: typeof precipitationChance === "number" ? Number(precipitationChance.toFixed(1)) : null,
+      wind_mph: typeof windMph === "number" ? Number(windMph.toFixed(1)) : (isDome ? 0 : null),
+      impact_score: typeof impactScore === "number" ? Number(impactScore.toFixed(2)) : (isDome ? 0 : null),
+      forecast_links: links,
+      fetched_at: fetchedAt,
+      source: "rotowire"
+    };
+    records.push(record);
+  });
+
+  if (!records.length) {
+    console.warn("[fetchRotowireWeather] No records parsed; aborting write.");
+    return;
+  }
+
+  await fs.mkdir(artifactsDir, { recursive: true });
+  const weekSuffix = `W${String(week).padStart(2, "0")}`;
+  const outPath = path.join(artifactsDir, `weather_${season}_${weekSuffix}.json`);
+  const currentPath = path.join(artifactsDir, "weather_current.json");
+  await fs.writeFile(outPath, JSON.stringify(records, null, 2));
+  await fs.writeFile(currentPath, JSON.stringify(records, null, 2));
+  console.log(`[fetchRotowireWeather] Wrote ${records.length} records -> ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error("[fetchRotowireWeather] Error:", err?.message || err);
+  process.exit(1);
+});

--- a/trainer/tests/weatherContext.test.js
+++ b/trainer/tests/weatherContext.test.js
@@ -1,0 +1,152 @@
+import { buildFeatures } from "../featureBuild.js";
+import { shapeWeatherContext } from "../contextPack.js";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function makeGame(season, week, home, away) {
+  return {
+    season,
+    week,
+    season_type: "REG",
+    home_team: home,
+    away_team: away,
+    game_id: `${season}-${week}-${home}-${away}`,
+    game_date: `${season}-09-01`,
+    roof: "outdoor"
+  };
+}
+
+function makeTeamRow(season, week, team, opponent) {
+  return {
+    season,
+    week,
+    season_type: "REG",
+    team,
+    opponent,
+    passing_yards: 220,
+    rushing_yards: 110,
+    passing_first_downs: 12,
+    rushing_first_downs: 8,
+    receiving_first_downs: 4,
+    penalties: 45,
+    penalty_yards: 45,
+    turnovers: 1,
+    passing_interceptions: 1,
+    rushing_fumbles_lost: 0,
+    receiving_fumbles_lost: 0,
+    sack_fumbles_lost: 0,
+    time_of_possession: "30:00"
+  };
+}
+
+function makeTeamGameRow(season, week, team) {
+  return {
+    season,
+    week,
+    team,
+    third_down_att: 12,
+    third_down_conv: 6,
+    red_zone_att: 4,
+    red_zone_td: 2,
+    pass_att: 32,
+    rush_att: 26,
+    sacks_taken: 2,
+    off_dropbacks: 34,
+    off_sacks_taken: 2
+  };
+}
+
+async function main() {
+  const season = 2023;
+  const week = 1;
+  const schedules = [makeGame(season, week, "A", "B")];
+  const teamWeekly = [
+    makeTeamRow(season, week, "A", "B"),
+    makeTeamRow(season, week, "B", "A")
+  ];
+  const teamGame = [
+    makeTeamGameRow(season, week, "A"),
+    makeTeamGameRow(season, week, "B")
+  ];
+
+  const weatherRows = [
+    {
+      season,
+      week,
+      home_team: "A",
+      away_team: "B",
+      temperature_f: 35,
+      precipitation_chance: 80,
+      wind_mph: 20,
+      impact_score: 0.6,
+      game_key: `${season}-W${String(week).padStart(2, "0")}-A-B`,
+      fetched_at: "2023-09-01T12:00:00Z"
+    }
+  ];
+
+  const features = buildFeatures({
+    teamWeekly,
+    teamGame,
+    schedules,
+    season,
+    prevTeamWeekly: [],
+    pbp: [],
+    playerWeekly: [],
+    weather: weatherRows
+  });
+
+  const homeRow = features.find((row) => row.team === "A" && row.week === week && row.season === season && row.home === 1);
+  const awayRow = features.find((row) => row.team === "B" && row.week === week && row.season === season && row.home === 0);
+
+  assert(homeRow, "Home row missing");
+  assert(awayRow, "Away row missing");
+
+  const expectedTemp = 35;
+  const expectedWind = 20;
+  const expectedPrecip = 80;
+  const expectedImpact = 0.6;
+
+  assert(Math.abs(homeRow.weather_temp_f - expectedTemp) < 1e-6, "Home weather temperature mismatch");
+  assert(Math.abs(homeRow.weather_wind_mph - expectedWind) < 1e-6, "Home weather wind mismatch");
+  assert(Math.abs(homeRow.weather_precip_pct - expectedPrecip) < 1e-6, "Home weather precip mismatch");
+  assert(Math.abs(homeRow.weather_impact_score - expectedImpact) < 1e-6, "Home weather impact mismatch");
+  assert(homeRow.weather_extreme_flag === 1, "Home weather extreme flag not set");
+
+  assert(Math.abs(awayRow.weather_temp_f - expectedTemp) < 1e-6, "Away weather temperature mismatch");
+  assert(Math.abs(awayRow.weather_wind_mph - expectedWind) < 1e-6, "Away weather wind mismatch");
+  assert(Math.abs(awayRow.weather_precip_pct - expectedPrecip) < 1e-6, "Away weather precip mismatch");
+  assert(Math.abs(awayRow.weather_impact_score - expectedImpact) < 1e-6, "Away weather impact mismatch");
+  assert(awayRow.weather_extreme_flag === 1, "Away weather extreme flag not set");
+
+  const shaped = shapeWeatherContext({
+    summary: "Rain",
+    details: "Heavy rain in Chicago",
+    notes: "Strong winds expected.",
+    temperature_f: 38,
+    precipitation_chance: 90,
+    wind_mph: 22,
+    impact_score: 0.7,
+    kickoff_display: "1:00 PM EST",
+    location: "Chicago, IL",
+    forecast_provider: "Forecast.io",
+    forecast_links: [{ label: "Weather.com", url: "https://weather.com" }],
+    icon: "https://example.com/icon.png",
+    fetched_at: "2023-09-01T12:00:00Z",
+    is_dome: false
+  });
+
+  assert(shaped.summary === "Rain", "shapeWeatherContext summary mismatch");
+  assert(shaped.forecast_links.length === 1 && shaped.forecast_links[0].url === "https://weather.com", "forecast link missing");
+  assert(shaped.weather_extreme_flag === undefined, "shapeWeatherContext should not expose derived flags");
+
+  console.log("Weather context + feature tests passed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/trainer/train.js
+++ b/trainer/train.js
@@ -3,7 +3,8 @@ import {
   loadSchedules,
   loadTeamWeekly,
   loadTeamGameAdvanced,
-  listDatasetSeasons
+  listDatasetSeasons,
+  loadWeather
 } from "./dataSources.js";
 import { buildFeatures, FEATS } from "./featureBuild.js";
 import { writeFileSync, mkdirSync } from "fs";
@@ -114,12 +115,15 @@ function round3(x){ return Math.round(Number(x)*1000)/1000; }
     try { teamGame = await loadTeamGameAdvanced(season); } catch (_) {}
     let prevTeamWeekly = [];
     try { prevTeamWeekly = await loadTeamWeekly(season - 1); } catch (_) {}
+    let weatherRows = [];
+    try { weatherRows = await loadWeather(season); } catch (_) {}
     const featRows = buildFeatures({
       teamWeekly,
       teamGame,
       schedules,
       season,
-      prevTeamWeekly
+      prevTeamWeekly,
+      weather: weatherRows
     });
     allRows.push(...featRows);
     seasonSummaries.push({ season, rows: featRows.length });

--- a/trainer/train_multi.js
+++ b/trainer/train_multi.js
@@ -14,7 +14,8 @@ import {
   loadSnapCounts,
   loadPFRAdvTeam,       // kept for compatibility; now returns weekly array
   loadESPNQBR,
-  loadOfficials
+  loadOfficials,
+  loadWeather
 } from "./dataSources.js";
 import { buildContextForWeek } from "./contextPack.js";
 import { writeExplainArtifact } from "./explainRubric.js";
@@ -371,7 +372,12 @@ const FEATURE_LABELS = {
   qb_sack_rate_w5: "QB sack rate (5wk)",
   qb_sack_rate_exp: "QB sack rate (exp)",
   roof_dome: "Dome roof flag",
-  roof_outdoor: "Outdoor roof flag"
+  roof_outdoor: "Outdoor roof flag",
+  weather_temp_f: "Forecast temperature (°F)",
+  weather_wind_mph: "Forecast wind (mph)",
+  weather_precip_pct: "Precipitation chance (%)",
+  weather_impact_score: "Weather impact score",
+  weather_extreme_flag: "Weather extreme flag"
 };
 
 function humanizeFeature(key) {
@@ -608,6 +614,17 @@ export async function runTraining({ season, week, data = {}, options = {} } = {}
     }
   }
 
+  let weatherRows;
+  if (data.weather !== undefined) {
+    weatherRows = data.weather;
+  } else {
+    try {
+      weatherRows = await loadWeather(resolvedSeason);
+    } catch (e) {
+      weatherRows = [];
+    }
+  }
+
   const featureRows = buildFeatures({
     teamWeekly,
     teamGame,
@@ -615,7 +632,8 @@ export async function runTraining({ season, week, data = {}, options = {} } = {}
     season: resolvedSeason,
     prevTeamWeekly,
     pbp: pbpData,
-    playerWeekly
+    playerWeekly,
+    weather: weatherRows
   });
   const btRows = buildBTFeatures({
     teamWeekly,

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -360,6 +360,12 @@ export default {
       if (path === "/context/current") {
         return await contextCurrentResponse();
       }
+      if (path === "/weather") {
+        return await respondWithArtifact("weather", url);
+      }
+      if (path === "/weather/current") {
+        return await respondWithArtifact("weather", url);
+      }
       if (path === "/explain") {
         return await respondWithArtifact("explain", url);
       }


### PR DESCRIPTION
## Summary
- add a Rotowire weather scraping script and npm hook for refreshing artifacts
- load weather artifacts into context packs, feature engineering, trainers, and the API schema
- expose weather artifacts through the worker and add regression coverage for weather features

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a7498d3483309555917c6f6b64e0