### PR TITLE
Add Rotowire weather ingestion to context build

### DIFF
--- a/.github/workflows/train.yaml
+++ b/.github/workflows/train.yaml
@@ -88,6 +88,13 @@ jobs:
           WEEK: ${{ steps.resolve.outputs.WEEK }}
         run: npm run fetch:markets -- --season=$SEASON --week=$WEEK
 
+      - name: Fetch Rotowire weather
+        env:
+          ROTOWIRE_ENABLED: 'true'
+          SEASON: ${{ env.SEASON }}
+          WEEK: ${{ steps.resolve.outputs.WEEK }}
+        run: npm run fetch:weather -- --season=$SEASON --week=$WEEK
+
       - name: Build context
         env:
           SEASON: ${{ env.SEASON }}


### PR DESCRIPTION
## Summary
- load Rotowire weather artifacts alongside injuries and markets when building the context database
- add weather snapshot/index exports to the context payload with normalized metadata
- ensure the training workflow fetches Rotowire weather data before building the context

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5ad0a57188330949c2a6fbf84b8b0