### PR TITLE
Add injury-driven features to model pipeline

### DIFF
--- a/scripts/debugData.js
+++ b/scripts/debugData.js
@@ -1,5 +1,5 @@
 // scripts/debugData.js
-import { loadSchedules, loadTeamWeekly, loadTeamGameAdvanced } from "../trainer/dataSources.js";
+import { loadSchedules, loadTeamWeekly, loadTeamGameAdvanced, loadInjuries } from "../trainer/dataSources.js";
 import { buildFeatures } from "../trainer/featureBuild.js";
 
 const SEASON = Number(process.env.SEASON || new Date().getFullYear());
@@ -48,7 +48,22 @@ function counts(arr, key) {
     console.log(`loadTeamWeekly(${SEASON - 1}) failed: ${e?.message || e}`);
   }
 
-  const featRows = buildFeatures({ teamWeekly, teamGame, schedules, season: SEASON, prevTeamWeekly });
+  let injuries = [];
+  try {
+    injuries = await loadInjuries(SEASON);
+    console.log(`injury rows (season ${SEASON}): ${injuries.length}`);
+  } catch (e) {
+    console.log(`loadInjuries(${SEASON}) failed: ${e?.message || e}`);
+  }
+
+  const featRows = buildFeatures({
+    teamWeekly,
+    teamGame,
+    schedules,
+    season: SEASON,
+    prevTeamWeekly,
+    injuries
+  });
   console.log(`feature rows (REG relaxed): ${featRows.length}`);
   const train = featRows.filter(r => r.season === SEASON && r.week < WEEK);
   const test  = featRows.filter(r => r.season === SEASON && r.week === WEEK);

--- a/trainer/injuryIndex.js
+++ b/trainer/injuryIndex.js
@@ -1,0 +1,147 @@
+// trainer/injuryIndex.js
+//
+// Shared helpers for transforming Rotowire injury artifacts into
+// per-team snapshots that downstream feature builders can consume.
+
+const KEY_SKILL_POSITIONS = new Set(["QB", "RB", "WR", "TE"]);
+const KEY_OFFENSIVE_LINE = new Set(["LT", "RT", "LG", "RG", "C", "OL", "T", "G", "OT", "OG"]);
+
+const ZERO_SNAPSHOT = Object.freeze({
+  total: 0,
+  out: 0,
+  questionable: 0,
+  doubtful: 0,
+  skill_out: 0,
+  skill_questionable: 0,
+  ol_out: 0,
+  ol_questionable: 0,
+  practice_dnp: 0,
+  practice_limited: 0
+});
+
+const normTeam = (value) => {
+  if (!value) return null;
+  const s = String(value).trim().toUpperCase();
+  return s || null;
+};
+
+const classifyStatus = (statusRaw = "") => {
+  if (!statusRaw) return null;
+  const status = String(statusRaw).toLowerCase();
+  if (!status) return null;
+  if (
+    status.includes("out") ||
+    status.includes("injured reserve") ||
+    status.includes("injury reserve") ||
+    status.includes("ir") ||
+    status.includes("susp") ||
+    status.includes("pup") ||
+    status.includes("nfi") ||
+    status.includes("covid")
+  ) {
+    return "out";
+  }
+  if (status.includes("doubt")) return "doubtful";
+  if (status.includes("question")) return "questionable";
+  if (status.includes("probable") || status.includes("game-time")) return "questionable";
+  return null;
+};
+
+const classifyPractice = (practiceRaw = "") => {
+  if (!practiceRaw) return null;
+  const practice = String(practiceRaw).toLowerCase();
+  if (!practice) return null;
+  if (
+    practice.includes("did not") ||
+    practice.includes("no practice") ||
+    practice.includes("dnp") ||
+    practice.includes("out")
+  ) {
+    return "dnp";
+  }
+  if (practice.includes("limited")) return "limited";
+  return null;
+};
+
+const cloneSnapshot = (snapshot = ZERO_SNAPSHOT) => ({
+  total: snapshot.total || 0,
+  out: snapshot.out || 0,
+  questionable: snapshot.questionable || 0,
+  doubtful: snapshot.doubtful || 0,
+  skill_out: snapshot.skill_out || 0,
+  skill_questionable: snapshot.skill_questionable || 0,
+  ol_out: snapshot.ol_out || 0,
+  ol_questionable: snapshot.ol_questionable || 0,
+  practice_dnp: snapshot.practice_dnp || 0,
+  practice_limited: snapshot.practice_limited || 0
+});
+
+export function buildTeamInjuryIndex(rows = [], season) {
+  const seasonNum = Number(season);
+  if (!Number.isFinite(seasonNum)) return new Map();
+  const index = new Map();
+  const dedup = new Set();
+  for (const row of rows || []) {
+    if (Number(row.season) !== seasonNum) continue;
+    const week = Number(row.week);
+    if (!Number.isFinite(week) || week < 1) continue;
+    const team = normTeam(row.team || row.team_abbr || row.recent_team || row.club_code);
+    if (!team) continue;
+    const player = String(row.player || row.player_name || row.gsis_id || row.esb_id || "").trim();
+    const statusRaw = row.status ?? row.injury_status ?? row.designation ?? "";
+    const practiceRaw = row.practice ?? row.practice_status ?? row.practice_notes ?? row.practice_text ?? "";
+    const dedupKey = `${seasonNum}|${week}|${team}|${player}|${statusRaw}|${practiceRaw}`;
+    if (dedup.has(dedupKey)) continue;
+    dedup.add(dedupKey);
+
+    let bucket = classifyStatus(statusRaw);
+    const practiceBucket = classifyPractice(practiceRaw);
+    if (!bucket && practiceBucket) {
+      // treat practice downgrades as questionable signals if no explicit status
+      bucket = "questionable";
+    }
+    if (!bucket && !practiceBucket) continue;
+
+    const key = `${seasonNum}-${week}-${team}`;
+    if (!index.has(key)) {
+      index.set(key, cloneSnapshot());
+    }
+    const snapshot = index.get(key);
+    snapshot.total += 1;
+    if (bucket === "out") {
+      snapshot.out += 1;
+    } else if (bucket) {
+      snapshot.questionable += 1;
+      if (bucket === "doubtful") snapshot.doubtful += 1;
+    }
+
+    const pos = String(row.position || row.pos || row.player_position || "").toUpperCase();
+    const isSkill = KEY_SKILL_POSITIONS.has(pos);
+    const isOl = KEY_OFFENSIVE_LINE.has(pos);
+    if (bucket === "out") {
+      if (isSkill) snapshot.skill_out += 1;
+      if (isOl) snapshot.ol_out += 1;
+    } else if (bucket) {
+      if (isSkill) snapshot.skill_questionable += 1;
+      if (isOl) snapshot.ol_questionable += 1;
+    }
+
+    if (practiceBucket === "dnp") snapshot.practice_dnp += 1;
+    else if (practiceBucket === "limited") snapshot.practice_limited += 1;
+  }
+  return index;
+}
+
+export function getTeamInjurySnapshot(index, season, week, team) {
+  if (!team) return cloneSnapshot();
+  const seasonNum = Number(season);
+  const weekNum = Number(week);
+  if (!Number.isFinite(seasonNum) || !Number.isFinite(weekNum) || weekNum < 1) {
+    return cloneSnapshot();
+  }
+  const key = `${seasonNum}-${weekNum}-${team}`;
+  const snapshot = index.get(key);
+  return cloneSnapshot(snapshot);
+}
+
+export const ZERO_INJURY_SNAPSHOT = cloneSnapshot();

--- a/trainer/tests/weatherContext.test.js
+++ b/trainer/tests/weatherContext.test.js
@@ -96,7 +96,8 @@ async function main() {
     prevTeamWeekly: [],
     pbp: [],
     playerWeekly: [],
-    weather: weatherRows
+    weather: weatherRows,
+    injuries: []
   });
 
   const homeRow = features.find((row) => row.team === "A" && row.week === week && row.season === season && row.home === 1);
@@ -115,12 +116,15 @@ async function main() {
   assert(Math.abs(homeRow.weather_precip_pct - expectedPrecip) < 1e-6, "Home weather precip mismatch");
   assert(Math.abs(homeRow.weather_impact_score - expectedImpact) < 1e-6, "Home weather impact mismatch");
   assert(homeRow.weather_extreme_flag === 1, "Home weather extreme flag not set");
+  assert(homeRow.inj_out_count === 0, "Home injury out count should default to 0");
+  assert(homeRow.inj_out_diff === 0, "Home injury diff should default to 0");
 
   assert(Math.abs(awayRow.weather_temp_f - expectedTemp) < 1e-6, "Away weather temperature mismatch");
   assert(Math.abs(awayRow.weather_wind_mph - expectedWind) < 1e-6, "Away weather wind mismatch");
   assert(Math.abs(awayRow.weather_precip_pct - expectedPrecip) < 1e-6, "Away weather precip mismatch");
   assert(Math.abs(awayRow.weather_impact_score - expectedImpact) < 1e-6, "Away weather impact mismatch");
   assert(awayRow.weather_extreme_flag === 1, "Away weather extreme flag not set");
+  assert(awayRow.inj_out_count === 0, "Away injury out count should default to 0");
 
   const shaped = shapeWeatherContext({
     summary: "Rain",

--- a/trainer/train.js
+++ b/trainer/train.js
@@ -4,7 +4,8 @@ import {
   loadTeamWeekly,
   loadTeamGameAdvanced,
   listDatasetSeasons,
-  loadWeather
+  loadWeather,
+  loadInjuries
 } from "./dataSources.js";
 import { buildFeatures, FEATS } from "./featureBuild.js";
 import { writeFileSync, mkdirSync } from "fs";
@@ -117,13 +118,16 @@ function round3(x){ return Math.round(Number(x)*1000)/1000; }
     try { prevTeamWeekly = await loadTeamWeekly(season - 1); } catch (_) {}
     let weatherRows = [];
     try { weatherRows = await loadWeather(season); } catch (_) {}
+    let injuryRows = [];
+    try { injuryRows = await loadInjuries(season); } catch (_) {}
     const featRows = buildFeatures({
       teamWeekly,
       teamGame,
       schedules,
       season,
       prevTeamWeekly,
-      weather: weatherRows
+      weather: weatherRows,
+      injuries: injuryRows
     });
     allRows.push(...featRows);
     seasonSummaries.push({ season, rows: featRows.length });

--- a/trainer/train_multi.js
+++ b/trainer/train_multi.js
@@ -663,6 +663,17 @@ export async function runTraining({ season, week, data = {}, options = {} } = {}
     }
   }
 
+  let injuryRows;
+  if (data.injuries !== undefined) {
+    injuryRows = data.injuries;
+  } else {
+    try {
+      injuryRows = await loadInjuries(resolvedSeason);
+    } catch (e) {
+      injuryRows = [];
+    }
+  }
+
   const featureRows = buildFeatures({
     teamWeekly,
     teamGame,
@@ -671,14 +682,16 @@ export async function runTraining({ season, week, data = {}, options = {} } = {}
     prevTeamWeekly,
     pbp: pbpData,
     playerWeekly,
-    weather: weatherRows
+    weather: weatherRows,
+    injuries: injuryRows
   });
   const btRows = buildBTFeatures({
     teamWeekly,
     teamGame,
     schedules,
     season: resolvedSeason,
-    prevTeamWeekly
+    prevTeamWeekly,
+    injuries: injuryRows
   });
 
   // --- Enrich feature rows with PFR advanced weekly differentials ---


### PR DESCRIPTION
## Summary
- add reusable injury indexing utilities and injury-aware features for team-level training data
- propagate injury snapshots into Bradley-Terry features, context packs, and supporting scripts
- update tests and tooling to validate the new injury feature outputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5f3d35d648330a103530d7f3dee69